### PR TITLE
zzre: Add doorway triggers

### DIFF
--- a/zzre.core/math/NumericsExtensions.cs
+++ b/zzre.core/math/NumericsExtensions.cs
@@ -40,15 +40,8 @@ namespace zzre
         public static Quaternion LookIn(Vector3 dir) => LookIn(dir, Vector3.UnitY);
         public static Quaternion LookIn(Vector3 dir, Vector3 up)
         {
-            dir = Vector3.Normalize(dir);
-            var right = Vector3.Normalize(Vector3.Cross(up, dir));
-            up = Vector3.Cross(dir, right);
-            var matrix = new Matrix4x4(
-                right.X, right.Y, right.Z, 0f,
-                up.X, up.Y, up.Z, 0f,
-                dir.X, dir.Y, dir.Z, 0f,
-                0f, 0f, 0f, 1f);
-            return Quaternion.CreateFromRotationMatrix(matrix);
+            var matrix = Matrix4x4.CreateLookAt(dir, Vector3.Zero, up);
+            return Quaternion.Inverse(Quaternion.CreateFromRotationMatrix(matrix));
         }
 
         public static (Vector3 right, Vector3 up, Vector3 forward) UnitVectors(this Quaternion q) => (

--- a/zzre/Program.cs
+++ b/zzre/Program.cs
@@ -36,6 +36,7 @@ namespace zzre
             {
                 renderDoc.APIValidation = true;
                 renderDoc.OverlayEnabled = false;
+                renderDoc.RefAllResources = true;
             }
 #endif
 

--- a/zzre/game/DefaultECSExtensions.cs
+++ b/zzre/game/DefaultECSExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace zzre.game;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+internal static class DefaultECSExtensions
+{
+    public static void DisposeAll(this DefaultEcs.EntityQueryBuilder builder)
+    {
+        Array.ForEach(
+            builder.AsEnumerable().ToArray(),
+            DisposeEntity);
+    }
+
+    public static void DisposeAll(this DefaultEcs.EntityQueryBuilder.EitherBuilder builder)
+    {
+        Array.ForEach(
+            builder.AsEnumerable().ToArray(),
+            DisposeEntity);
+    }
+
+    public static void DisposeAll(this DefaultEcs.EntitySet set)
+    {
+        Array.ForEach(
+            set.GetEntities().ToArray(),
+            DisposeEntity);
+    }
+
+    private static void DisposeEntity(DefaultEcs.Entity e) => e.Dispose();
+}

--- a/zzre/game/Game.cs
+++ b/zzre/game/Game.cs
@@ -107,6 +107,7 @@ namespace zzre.game
                 new systems.TriggerCamera(this),
                 new systems.CreatureCamera(this),
                 new systems.GotCard(this),
+                new systems.Doorway(this),
                 new systems.Reaper(this),
                 new systems.ParentReaper(this));
             updateSystems.Add(new systems.PauseDuring(this, updateSystems.Systems));

--- a/zzre/game/components/GameFlow.cs
+++ b/zzre/game/components/GameFlow.cs
@@ -5,5 +5,6 @@
 public enum GameFlow
 {
     Normal,
-    GotCard
+    GotCard,
+    Doorway
 }

--- a/zzre/game/components/HumanPhysics.cs
+++ b/zzre/game/components/HumanPhysics.cs
@@ -4,7 +4,8 @@ namespace zzre.game.components
 {
     public struct HumanPhysics
     {
-        public const float DefaultSpeedModifier = 1f;
+        public const float ExteriorSpeedModifier = 1f;
+        public const float InteriorSpeedModifier = 0.6f;
 
         public enum AnimationState
         {
@@ -24,15 +25,15 @@ namespace zzre.game.components
         public bool HitCeiling;
         public bool IsDrowning;
         public bool IsWading;
-        public bool ShouldCollideWithModels;
+        public float DisableModelCollisionTimer;
         public bool DidCollideWithWorld;
 
         public HumanPhysics(float colliderSize)
         {
             ColliderSize = colliderSize;
             GravityModifier = 1f;
-            SpeedModifier = DefaultSpeedModifier;
-            ShouldCollideWithModels = true;
+            SpeedModifier = ExteriorSpeedModifier;
+            DisableModelCollisionTimer = 0f;
 
             Velocity = Vector3.Zero;
             State = AnimationState.Idle;

--- a/zzre/game/components/PlayerEntity.cs
+++ b/zzre/game/components/PlayerEntity.cs
@@ -1,0 +1,3 @@
+﻿namespace zzre.game.components;
+
+public readonly record struct PlayerEntity(DefaultEcs.Entity Entity);

--- a/zzre/game/components/npc/NPCLookAtTrigger.cs
+++ b/zzre/game/components/npc/NPCLookAtTrigger.cs
@@ -4,7 +4,8 @@
     {
         public readonly int TriggerIdx;
         public float TimeLeft;
+        public zzio.scn.Trigger? Trigger;
 
-        public NPCLookAtTrigger(int triggerIdx, float duration) => (TriggerIdx, TimeLeft) = (triggerIdx, duration);
+        public NPCLookAtTrigger(int triggerIdx, float duration) => (TriggerIdx, TimeLeft, Trigger) = (triggerIdx, duration, null);
     }
 }

--- a/zzre/game/messages/LockPlayerControl.cs
+++ b/zzre/game/messages/LockPlayerControl.cs
@@ -2,7 +2,7 @@
 
 namespace zzre.game.messages
 {
-    public record struct LockPlayerControl(float Duration)
+    public record struct LockPlayerControl(float Duration, bool MovingForward = false)
     {
         public static readonly LockPlayerControl Unlock = default;
         public static readonly LockPlayerControl Forever = new LockPlayerControl(float.PositiveInfinity);

--- a/zzre/game/messages/LockPlayerControl.cs
+++ b/zzre/game/messages/LockPlayerControl.cs
@@ -5,6 +5,6 @@ namespace zzre.game.messages
     public record struct LockPlayerControl(float Duration, bool MovingForward = false)
     {
         public static readonly LockPlayerControl Unlock = default;
-        public static readonly LockPlayerControl Forever = new LockPlayerControl(float.PositiveInfinity);
+        public static readonly LockPlayerControl Forever = new(float.PositiveInfinity);
     }
 }

--- a/zzre/game/messages/PlayerEntered.cs
+++ b/zzre/game/messages/PlayerEntered.cs
@@ -1,0 +1,3 @@
+﻿namespace zzre.game.messages;
+
+public record struct PlayerEntered(zzio.scn.Trigger EntryTrigger);

--- a/zzre/game/messages/SceneChanging.cs
+++ b/zzre/game/messages/SceneChanging.cs
@@ -1,0 +1,4 @@
+﻿namespace zzre.game.messages;
+
+// triggered to clear all scene-specific entities to prepare for loading
+public record struct SceneChanging;

--- a/zzre/game/messages/SceneLoaded.cs
+++ b/zzre/game/messages/SceneLoaded.cs
@@ -1,9 +1,9 @@
-﻿namespace zzre.game.messages
-{
-    public readonly struct SceneLoaded
-    {
-        public readonly int entryId;
+﻿namespace zzre.game.messages;
+using zzio.scn;
 
-        public SceneLoaded(int entryId) => this.entryId = entryId;
-    }
+public readonly struct SceneLoaded
+{
+    public readonly Scene Scene;
+
+    public SceneLoaded(Scene scene) => this.Scene = scene;
 }

--- a/zzre/game/resources/ClumpMaterial.cs
+++ b/zzre/game/resources/ClumpMaterial.cs
@@ -79,7 +79,8 @@ namespace zzre.game.resources
 
         protected override void Unload(ClumpMaterialInfo info, BaseModelInstancedMaterial resource)
         {
-            resource.MainTexture.Texture?.Dispose();
+            if (textureLoader is not CachedAssetLoader<Texture>)
+                resource.MainTexture.Texture?.Dispose();
             resource.Dispose();
         }
     }

--- a/zzre/game/systems/ActorRenderer.cs
+++ b/zzre/game/systems/ActorRenderer.cs
@@ -98,8 +98,8 @@ namespace zzre.game.systems
         {
             foreach (var material in materials)
             {
-                material.MainTexture.Dispose();
-                material.Sampler.Dispose();
+                material.MainTexture.Texture?.Dispose();
+                material.Sampler.Sampler.Dispose();
                 material.Dispose();
             }
         }

--- a/zzre/game/systems/ParentReaper.cs
+++ b/zzre/game/systems/ParentReaper.cs
@@ -1,18 +1,28 @@
-﻿using DefaultEcs.System;
+﻿namespace zzre.game.systems;
+using System;
+using DefaultEcs.System;
 
-namespace zzre.game.systems
+public partial class ParentReaper : AEntitySetSystem<float>
 {
-    public partial class ParentReaper : AEntitySetSystem<float>
-    {
-        public ParentReaper(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
-        {
-        }
+    private readonly IDisposable sceneChangingSubscription;
 
-        [Update]
-        private void Update(in DefaultEcs.Entity entity, in components.Parent parent)
-        {
-            if (!parent.Entity.IsAlive)
-                entity.Dispose();
-        }
+    public ParentReaper(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
+    {
+        sceneChangingSubscription = World.Subscribe<messages.SceneChanging>(HandleSceneChanging);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        sceneChangingSubscription.Dispose();
+    }
+
+    private void HandleSceneChanging(in messages.SceneChanging _) => Update(0f);
+
+    [Update]
+    private void Update(in DefaultEcs.Entity entity, in components.Parent parent)
+    {
+        if (!parent.Entity.IsAlive)
+            entity.Dispose();
     }
 }

--- a/zzre/game/systems/PuppetActorMovement.cs
+++ b/zzre/game/systems/PuppetActorMovement.cs
@@ -13,16 +13,16 @@ namespace zzre.game.systems
         private const float GroundFromOffset = 1f;
         private const float GroundToOffset = -7f;
 
+        private readonly IDisposable sceneLoadedSubscription;
         private readonly IDisposable addedSubscription;
         private readonly IDisposable placeToGroundSubscription;
         private readonly IDisposable placeToTriggerSubscription;
-        private readonly WorldCollider worldCollider;
-        private readonly Scene scene;
+        private WorldCollider worldCollider = null!;
+        private Scene scene = null!;
 
         public PuppetActorMovement(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
-            worldCollider = diContainer.GetTag<WorldCollider>();
-            scene = diContainer.GetTag<Scene>();
+            sceneLoadedSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             addedSubscription = World.SubscribeComponentAdded<components.PuppetActorMovement>(HandleComponentAdded);
             placeToGroundSubscription = World.Subscribe<messages.CreaturePlaceToGround>(HandlePlaceToGround);
             placeToTriggerSubscription = World.Subscribe<messages.CreaturePlaceToTrigger>(HandlePlaceToTrigger);
@@ -34,6 +34,12 @@ namespace zzre.game.systems
             addedSubscription.Dispose();
             placeToGroundSubscription.Dispose();
             placeToTriggerSubscription.Dispose();
+        }
+
+        private void HandleSceneLoaded(in messages.SceneLoaded message)
+        {
+            scene = message.Scene;
+            worldCollider = World.Get<WorldCollider>();
         }
 
         private void HandleComponentAdded(in DefaultEcs.Entity entity, in components.PuppetActorMovement movement)

--- a/zzre/game/systems/TriggerActivation.cs
+++ b/zzre/game/systems/TriggerActivation.cs
@@ -12,6 +12,7 @@ namespace zzre.game.systems
     {
         private readonly float MaxLookingDistSqr = 0.81f;
 
+        private readonly IDisposable sceneChangingSubscription;
         private readonly IDisposable sceneLoadedSubscription;
         private readonly IDisposable disableTriggerSubscription;
         private Location playerLocation => playerLocationLazy.Value;
@@ -21,6 +22,7 @@ namespace zzre.game.systems
         {
             var game = diContainer.GetTag<Game>();
             playerLocationLazy = new Lazy<Location>(() => game.PlayerEntity.Get<Location>());
+            sceneChangingSubscription = World.Subscribe<messages.SceneChanging>(HandleSceneChanging);
             sceneLoadedSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             disableTriggerSubscription = World.Subscribe<zzio.GSModDisableTrigger>(HandleDisableTrigger);
         }
@@ -28,9 +30,12 @@ namespace zzre.game.systems
         public override void Dispose()
         {
             base.Dispose();
-            sceneLoadedSubscription?.Dispose();
-            disableTriggerSubscription?.Dispose();
+            sceneChangingSubscription.Dispose();
+            sceneLoadedSubscription.Dispose();
+            disableTriggerSubscription.Dispose();
         }
+
+        private void HandleSceneChanging(in messages.SceneChanging _) => Set.DisposeAll();
 
         private void HandleSceneLoaded(in messages.SceneLoaded msg)
         {

--- a/zzre/game/systems/TriggerActivation.cs
+++ b/zzre/game/systems/TriggerActivation.cs
@@ -35,7 +35,10 @@ namespace zzre.game.systems
             disableTriggerSubscription.Dispose();
         }
 
-        private void HandleSceneChanging(in messages.SceneChanging _) => Set.DisposeAll();
+        private void HandleSceneChanging(in messages.SceneChanging _) => World //  Set is filtered by collider
+            .GetEntities()
+            .With<Trigger>()
+            .DisposeAll();
 
         private void HandleSceneLoaded(in messages.SceneLoaded msg)
         {

--- a/zzre/game/systems/TriggerActivation.cs
+++ b/zzre/game/systems/TriggerActivation.cs
@@ -14,14 +14,12 @@ namespace zzre.game.systems
 
         private readonly IDisposable sceneLoadedSubscription;
         private readonly IDisposable disableTriggerSubscription;
-        private readonly Scene scene;
         private Location playerLocation => playerLocationLazy.Value;
         private readonly Lazy<Location> playerLocationLazy;
 
         public TriggerActivation(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
             var game = diContainer.GetTag<Game>();
-            scene = diContainer.GetTag<Scene>();
             playerLocationLazy = new Lazy<Location>(() => game.PlayerEntity.Get<Location>());
             sceneLoadedSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             disableTriggerSubscription = World.Subscribe<zzio.GSModDisableTrigger>(HandleDisableTrigger);
@@ -42,7 +40,7 @@ namespace zzre.game.systems
                 .Select(e => e.Get<Trigger>())
                 .ToHashSet();
 
-            foreach (var trigger in scene.triggers.Except(triggersWithEntities))
+            foreach (var trigger in msg.Scene.triggers.Except(triggersWithEntities))
             {
                 var entity = World.CreateEntity();
                 entity.Set(new Location()

--- a/zzre/game/systems/animal/Animal.cs
+++ b/zzre/game/systems/animal/Animal.cs
@@ -13,17 +13,20 @@ namespace zzre.game.systems
     {
         private readonly DefaultEcs.World ecsWorld;
         private readonly IDisposable sceneLoadSubscription;
+        private readonly IDisposable sceneChangingSubscription;
 
         public Animal(ITagContainer diContainer)
         {
             ecsWorld = diContainer.GetTag<DefaultEcs.World>();
             sceneLoadSubscription = ecsWorld.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
+            sceneChangingSubscription = ecsWorld.Subscribe<messages.SceneChanging>(HandleSceneChanging);
         }
 
         protected override void DisposeManaged()
         {
             base.DisposeManaged();
             sceneLoadSubscription.Dispose();
+            sceneChangingSubscription.Dispose();
         }
 
         public bool IsEnabled { get; set; } = true;
@@ -31,6 +34,13 @@ namespace zzre.game.systems
         public void Update(float state)
         {
         }
+
+        private void HandleSceneChanging(in messages.SceneChanging _) => ecsWorld
+            .GetEntities()
+            .WithEither<components.Butterfly>()
+            .Or<components.CirclingBird>()
+            .Or<components.AnimalWaypointAI>()
+            .DisposeAll();
 
         private void HandleSceneLoaded(in messages.SceneLoaded message)
         {

--- a/zzre/game/systems/animal/Animal.cs
+++ b/zzre/game/systems/animal/Animal.cs
@@ -11,13 +11,11 @@ namespace zzre.game.systems
 {
     public class Animal : BaseDisposable, ISystem<float>
     {
-        private readonly Scene scene;
         private readonly DefaultEcs.World ecsWorld;
         private readonly IDisposable sceneLoadSubscription;
 
         public Animal(ITagContainer diContainer)
         {
-            scene = diContainer.GetTag<Scene>();
             ecsWorld = diContainer.GetTag<DefaultEcs.World>();
             sceneLoadSubscription = ecsWorld.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
         }
@@ -39,6 +37,7 @@ namespace zzre.game.systems
             if (!IsEnabled)
                 return;
 
+            var scene = message.Scene;
             foreach (var trigger in scene.triggers
                 .Where(t => t.type == TriggerType.Animal)
                 .Where(t =>

--- a/zzre/game/systems/animal/AnimalWaypointAI.cs
+++ b/zzre/game/systems/animal/AnimalWaypointAI.cs
@@ -20,8 +20,6 @@ namespace zzre.game.systems
         private const float GroundDistance = 5f;
 
         private readonly Game game;
-        private readonly Scene scene;
-        private readonly WorldCollider worldCollider;
         private readonly IDisposable sceneLoadedSubscription;
         private readonly IDisposable addSubscription;
         private Trigger[] waypoints = Array.Empty<Trigger>();
@@ -29,8 +27,6 @@ namespace zzre.game.systems
         public AnimalWaypointAI(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
             game = diContainer.GetTag<Game>();
-            scene = diContainer.GetTag<Scene>();
-            worldCollider = diContainer.GetTag<WorldCollider>();
             sceneLoadedSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             addSubscription = World.SubscribeComponentAdded<components.AnimalWaypointAI>(HandleAddedComponent);
         }
@@ -44,6 +40,7 @@ namespace zzre.game.systems
 
         private void HandleSceneLoaded(in messages.SceneLoaded message)
         {
+            var scene = message.Scene;
             waypoints = scene.triggers
                 .Where(t => t.type == TriggerType.AnimalWaypoint)
                 .ToArray();
@@ -211,6 +208,7 @@ namespace zzre.game.systems
         private void PutOnGround(DefaultEcs.Entity entity, in components.AnimalWaypointAI ai)
         {
             var location = entity.Get<Location>();
+            var worldCollider = World.Get<WorldCollider>();
             var cast = worldCollider.Cast(new Line(
                 location.GlobalPosition + Vector3.UnitY * GroundDistance,
                 location.GlobalPosition - Vector3.UnitY * GroundDistance));

--- a/zzre/game/systems/camera/OverworldCamera.cs
+++ b/zzre/game/systems/camera/OverworldCamera.cs
@@ -22,6 +22,7 @@ namespace zzre.game.systems
         private const float NearHeightFactor = 1f / 5f;
 
         private readonly IDisposable sceneLoadedSubscription;
+        private readonly IDisposable playerEnteredSubscription;
         private readonly IDisposable setCameraModeDisposable;
         private float maxCameraDistance;
         private float currentVerAngle;
@@ -32,6 +33,7 @@ namespace zzre.game.systems
             curCamDistance = maxCameraDistance;
 
             sceneLoadedSubscription = world.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
+            playerEnteredSubscription = world.Subscribe<messages.PlayerEntered>(HandlePlayerEntered);
             setCameraModeDisposable = world.Subscribe<messages.SetCameraMode>(HandleSetCameraMode);
         }
 
@@ -39,6 +41,7 @@ namespace zzre.game.systems
         {
             base.Dispose();
             sceneLoadedSubscription.Dispose();
+            playerEnteredSubscription.Dispose();
             setCameraModeDisposable.Dispose();
         }
 
@@ -47,6 +50,12 @@ namespace zzre.game.systems
             maxCameraDistance = message.Scene.dataset.isInterior
                 ? MaxCamDistInterior
                 : MaxCamDistExterior;
+        }
+
+        private void HandlePlayerEntered(in messages.PlayerEntered _)
+        {
+            currentVerAngle = 0f;
+            curCamDistance = maxCameraDistance;
         }
 
         private void HandleSetCameraMode(in messages.SetCameraMode mode)

--- a/zzre/game/systems/camera/OverworldCamera.cs
+++ b/zzre/game/systems/camera/OverworldCamera.cs
@@ -21,26 +21,32 @@ namespace zzre.game.systems
         private const float NearHeightDistance = 0.5f;
         private const float NearHeightFactor = 1f / 5f;
 
+        private readonly IDisposable sceneLoadedSubscription;
         private readonly IDisposable setCameraModeDisposable;
-        private readonly float maxCameraDistance;
+        private float maxCameraDistance;
         private float currentVerAngle;
         private float curCamDistance;
 
         public OverworldCamera(ITagContainer diContainer) : base(diContainer)
         {
-            var scene = diContainer.GetTag<zzio.scn.Scene>();
-            maxCameraDistance = scene.dataset.isInterior
-                ? MaxCamDistInterior
-                : MaxCamDistExterior;
             curCamDistance = maxCameraDistance;
 
+            sceneLoadedSubscription = world.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             setCameraModeDisposable = world.Subscribe<messages.SetCameraMode>(HandleSetCameraMode);
         }
 
         public override void Dispose()
         {
             base.Dispose();
+            sceneLoadedSubscription.Dispose();
             setCameraModeDisposable.Dispose();
+        }
+
+        private void HandleSceneLoaded(in messages.SceneLoaded message)
+        {
+            maxCameraDistance = message.Scene.dataset.isInterior
+                ? MaxCamDistInterior
+                : MaxCamDistExterior;
         }
 
         private void HandleSetCameraMode(in messages.SetCameraMode mode)

--- a/zzre/game/systems/camera/OverworldCamera.cs
+++ b/zzre/game/systems/camera/OverworldCamera.cs
@@ -56,6 +56,9 @@ namespace zzre.game.systems
         {
             currentVerAngle = 0f;
             curCamDistance = maxCameraDistance;
+
+            camera.Location.LocalPosition = playerLocation.LocalPosition;
+            camera.Location.LocalRotation = playerLocation.LocalRotation;
         }
 
         private void HandleSetCameraMode(in messages.SetCameraMode mode)

--- a/zzre/game/systems/camera/OverworldCamera.cs
+++ b/zzre/game/systems/camera/OverworldCamera.cs
@@ -5,8 +5,8 @@ namespace zzre.game.systems
 {
     public class OverworldCamera : BaseGameCamera
     {
-        private static readonly Vector2 SpeedFactor = new Vector2(15f, 0.1f);
-        private static readonly Vector3 CameraDirectionFactor = new Vector3(1f, 0.2f, 1f);
+        private static readonly Vector2 SpeedFactor = new(15f, 0.1f);
+        private static readonly Vector3 CameraDirectionFactor = new(1f, 0.2f, 1f);
         private const float HorizontalDeadzone = 0.5f;
         private const float AdditionalHeight = 1f;
         private const float MaxVerAngle = 1.3f;

--- a/zzre/game/systems/camera/TriggerCamera.cs
+++ b/zzre/game/systems/camera/TriggerCamera.cs
@@ -13,7 +13,6 @@ namespace zzre.game.systems
         private const int MajorModeLookAtNpc = 50;
         private const double LerpSpeed = 9.999999960041972e-13;
 
-        private readonly Scene scene;
         private readonly IDisposable setCameraModeDisposable;
 
         private Trigger trigger = new Trigger();
@@ -22,7 +21,6 @@ namespace zzre.game.systems
 
         public TriggerCamera(ITagContainer diContainer) : base(diContainer)
         {
-            scene = diContainer.GetTag<Scene>();
             setCameraModeDisposable = world.Subscribe<messages.SetCameraMode>(HandleSetCameraMode);
         }
 
@@ -39,14 +37,15 @@ namespace zzre.game.systems
                 return;
 
             int triggerI = mode.Mode % 100;
-            var newTrigger = scene.triggers
-                .Where(t => t.type == TriggerType.CameraPosition)
-                .FirstOrDefault(t => t.ii1 == triggerI);
-            if (newTrigger == null)
+            var newTrigger = world.GetEntities()
+                .With((in Trigger t) => t.type == TriggerType.CameraPosition && t.ii1 == triggerI)
+                .AsEnumerable()
+                .FirstOrDefault();
+            if (newTrigger == default)
                 return;
 
             IsEnabled = majorMode != MajorModeTriggerDir; // no update necessary for trigger dir
-            trigger = newTrigger;
+            trigger = newTrigger.Get<Trigger>();
             npcLocation = mode.NPCEntity.Get<Location>();
 
             if (majorMode != MajorModeOriginalDir)

--- a/zzre/game/systems/camera/TriggerCamera.cs
+++ b/zzre/game/systems/camera/TriggerCamera.cs
@@ -15,8 +15,8 @@ namespace zzre.game.systems
 
         private readonly IDisposable setCameraModeDisposable;
 
-        private Trigger trigger = new Trigger();
-        private Location npcLocation = new Location();
+        private Trigger trigger = new();
+        private Location npcLocation = new();
         private int majorMode;
 
         public TriggerCamera(ITagContainer diContainer) : base(diContainer)

--- a/zzre/game/systems/dialog/DialogScript.Inventory.cs
+++ b/zzre/game/systems/dialog/DialogScript.Inventory.cs
@@ -66,17 +66,7 @@ namespace zzre.game.systems
             NPCEntity.Get<Inventory>().ClearDeck();
         }
 
-        private void Revive(DefaultEcs.Entity entity)
-        {
-            var playerInv = PlayerInventory;
-            for (int i = 0; i < Inventory.FairySlotCount; i++)
-            {
-                var invFairy = playerInv.GetFairyAtSlot(i);
-                if (invFairy != null)
-                    playerInv.FillMana(invFairy); // yes no actual revival, just mana fill
-            }
-        }
-
+        private void Revive(DefaultEcs.Entity entity) => PlayerInventory.FillMana();
         private const int MaxPresentFairyId = 77;
         private void GivePlayerPresent(DefaultEcs.Entity entity)
         {

--- a/zzre/game/systems/dialog/DialogScript.cs
+++ b/zzre/game/systems/dialog/DialogScript.cs
@@ -44,7 +44,6 @@ namespace zzre.game.systems
 
         private readonly MappedDB db;
         private readonly UI ui;
-        private readonly Scene scene;
         private readonly Game game;
         private readonly zzio.Savegame savegame;
         private readonly EntityCommandRecorder recorder;
@@ -60,7 +59,6 @@ namespace zzre.game.systems
             World.SetMaxCapacity<components.DialogState>(1);
             db = diContainer.GetTag<MappedDB>();
             ui = diContainer.GetTag<UI>();
-            scene = diContainer.GetTag<Scene>();
             game = diContainer.GetTag<Game>();
             savegame = diContainer.GetTag<zzio.Savegame>();
             recorder = diContainer.GetTag<EntityCommandRecorder>();
@@ -72,6 +70,7 @@ namespace zzre.game.systems
         {
             base.Dispose();
             startDialogDisposable.Dispose();
+            removedDisposable.Dispose();
         }
 
         private void HandleStartDialog(in messages.StartDialog message)

--- a/zzre/game/systems/fairy/FairyHoverBehind.cs
+++ b/zzre/game/systems/fairy/FairyHoverBehind.cs
@@ -4,18 +4,43 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using DefaultEcs.System;
-
 using Mode = zzre.game.components.FairyHoverBehind.Mode;
 
 public partial class FairyHoverBehind : AEntitySetSystem<float>
 {
     private readonly Random random = GlobalRandom.Get;
     private readonly GameTime time;
+    private readonly IDisposable playerEnteredSubscription;
+    private readonly IDisposable addedSubscription;
     private WorldCollider? worldCollider;
 
     public FairyHoverBehind(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: false)
     {
         time = diContainer.GetTag<GameTime>();
+        playerEnteredSubscription = World.Subscribe<messages.PlayerEntered>(HandlePlayerEntered);
+        addedSubscription = World.SubscribeComponentAdded<components.FairyHoverBehind>(HandleAddedComponent);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        playerEnteredSubscription.Dispose();
+        addedSubscription.Dispose();
+    }
+
+    private void HandlePlayerEntered(in messages.PlayerEntered _)
+    {
+        foreach (var entity in Set.GetEntities())
+            ResetPosition(entity);
+    }
+
+    private void HandleAddedComponent(in DefaultEcs.Entity entity, in components.FairyHoverBehind value) =>
+        ResetPosition(entity);
+
+    private void ResetPosition(in DefaultEcs.Entity entity)
+    {
+        var parent = entity.Get<components.Parent>().Entity;
+        entity.Get<Location>().LocalPosition = parent.Get<Location>().LocalPosition;
     }
 
     [Update]

--- a/zzre/game/systems/fairy/FairyHoverBehind.cs
+++ b/zzre/game/systems/fairy/FairyHoverBehind.cs
@@ -11,12 +11,11 @@ public partial class FairyHoverBehind : AEntitySetSystem<float>
 {
     private readonly Random random = GlobalRandom.Get;
     private readonly GameTime time;
-    private readonly WorldCollider worldCollider;
+    private WorldCollider? worldCollider;
 
     public FairyHoverBehind(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: false)
     {
         time = diContainer.GetTag<GameTime>();
-        worldCollider = diContainer.GetTag<WorldCollider>();
     }
 
     [Update]
@@ -66,6 +65,7 @@ public partial class FairyHoverBehind : AEntitySetSystem<float>
             location.LocalPosition = location.LocalPosition with { Y = minYPos };
         velocity = new(move);
 
+        worldCollider ??= World.Get<WorldCollider>();
         if (worldCollider.Intersects(new Sphere(location.LocalPosition, 0.6f)))
         {
             hoverBehind.TimeLeft = 3f;

--- a/zzre/game/systems/fairy/OverworldFairySpawner.cs
+++ b/zzre/game/systems/fairy/OverworldFairySpawner.cs
@@ -10,11 +10,13 @@ namespace zzre.game.systems
     public partial class OverworldFairySpawner : AEntitySetSystem<float>
     {
         private readonly zzio.db.MappedDB db;
+        private readonly IDisposable sceneChangingSubscription;
         private readonly IDisposable inventoryAddedSubscription;
 
         public OverworldFairySpawner(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
             db = diContainer.GetTag<zzio.db.MappedDB>();
+            sceneChangingSubscription = World.Subscribe<messages.SceneChanging>(HandleSceneChanging);
             inventoryAddedSubscription = World.SubscribeComponentAdded<Inventory>(HandleInventoryAdded);
         }
 
@@ -24,9 +26,15 @@ namespace zzre.game.systems
             inventoryAddedSubscription.Dispose();
         }
 
+        private void HandleSceneChanging(in messages.SceneChanging _) => World
+            .GetEntities()
+            .With<components.FairyHoverBehind>()
+            .DisposeAll();
+
         private void HandleInventoryAdded(in DefaultEcs.Entity entity, in Inventory value)
         {
             entity.Set(new components.SpawnedFairy());
+            Update(entity, value, ref entity.Get<components.SpawnedFairy>()); // no need to wait for next frame
         }
 
         [Update]

--- a/zzre/game/systems/fairy/OverworldFairySpawner.cs
+++ b/zzre/game/systems/fairy/OverworldFairySpawner.cs
@@ -49,7 +49,8 @@ namespace zzre.game.systems
                 : null;
             if (actualFairy == intendedFairy)
                 return;
-            spawnedFairy.Entity.Dispose();
+            if (spawnedFairy.Entity.IsAlive)
+                spawnedFairy.Entity.Dispose();
             spawnedFairy.Entity = default;
             if (intendedFairy == null)
                 return;

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -5,9 +5,8 @@ using DefaultEcs.System;
 using zzio.scn;
 
 [PauseDuring(PauseTrigger.UIScreen)]
-public partial class Doorway : ISystem<float>
+public partial class Doorway : AEntitySetSystem<float>
 {
-    private readonly DefaultEcs.World ecsWorld;
     private readonly Game game;
     private readonly IDisposable doorwayTriggerDisposable;
 
@@ -15,17 +14,15 @@ public partial class Doorway : ISystem<float>
     private int targetEntry;
     private float fadeOffTime; // just a placeholder, will be removed after actual fade off exists
 
-    public bool IsEnabled { get; set; } = true;
-
-    public Doorway(ITagContainer diContainer)
+    public Doorway(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
     {
-        ecsWorld = diContainer.GetTag<DefaultEcs.World>();
         game = diContainer.GetTag<Game>();
-        doorwayTriggerDisposable = ecsWorld.SubscribeComponentAdded<components.ActiveTrigger>(HandleActiveTrigger);
+        doorwayTriggerDisposable = World.SubscribeComponentAdded<components.ActiveTrigger>(HandleActiveTrigger);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
+        base.Dispose();
         doorwayTriggerDisposable?.Dispose();
     }
 
@@ -38,15 +35,20 @@ public partial class Doorway : ISystem<float>
         if (trigger.type != TriggerType.Doorway)
             return;
 
+        World.Get<components.PlayerEntity>().Entity.Set(components.GameFlow.Doorway);
         targetScene = $"sc_{trigger.ii3}";
         targetEntry = (int)trigger.ii2;
         fadeOffTime = 0.6f;
-        ecsWorld.Publish(messages.LockPlayerControl.Forever);
+        World.Publish(messages.LockPlayerControl.Forever);
         // TODO: Add fade off during scene changes
         // TODO: Fade off music and ambient sounds during scene changes
     }
 
-    public void Update(float elapsedTime)
+    [WithPredicate]
+    private static bool IsInGameFlow(in components.GameFlow flow) => flow == components.GameFlow.Doorway;
+
+    [Update]
+    private new void Update(float elapsedTime, in DefaultEcs.Entity entity)
     {
         if (fadeOffTime <= 0f)
             return;
@@ -54,14 +56,15 @@ public partial class Doorway : ISystem<float>
         if (fadeOffTime > 0f)
             return;
 
-        ecsWorld.Publish(new messages.SceneChanging());
+        World.Publish(new messages.SceneChanging());
         game.LoadScene(targetScene);
-        ecsWorld.Publish(new messages.PlayerEntered(FindEntryTrigger()));
+        World.Publish(new messages.PlayerEntered(FindEntryTrigger()));
+        entity.Set(components.GameFlow.Normal);
     }
 
     private Trigger? TryFindTrigger(TriggerType type, int ii1 = -1)
     {
-        var triggerEntity = ecsWorld
+        var triggerEntity = World
             .GetEntities()
             .With((in Trigger t) => t.type == type && (ii1 < 0 || t.ii1 == ii1))
             .AsEnumerable()

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -56,7 +56,9 @@ public partial class Doorway : AEntitySetSystem<float>
         if (fadeOffTime > 0f)
             return;
 
+        var prevCount = World.Count();
         World.Publish(new messages.SceneChanging());
+        Console.WriteLine($"Entity count before: {prevCount} after {World.Count()}");
         game.LoadScene(targetScene);
         World.Publish(new messages.PlayerEntered(FindEntryTrigger()));
         entity.Set(components.GameFlow.Normal);

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -58,9 +58,10 @@ public partial class Doorway : AEntitySetSystem<float>
 
         var prevCount = World.Count();
         World.Publish(new messages.SceneChanging());
-        Console.WriteLine($"Entity count before: {prevCount} after {World.Count()}");
+        var cleared = World.Count();
         World.Publish(messages.LockPlayerControl.Unlock); // otherwise the timed entry locking will be ignored
         game.LoadScene(targetScene);
+        Console.WriteLine($"Entity count before: {prevCount} cleared: {cleared} loaded: {World.Count()}");
         World.Publish(new messages.PlayerEntered(FindEntryTrigger()));
         entity.Set(components.GameFlow.Normal);
     }

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -56,12 +56,9 @@ public partial class Doorway : AEntitySetSystem<float>
         if (fadeOffTime > 0f)
             return;
 
-        var prevCount = World.Count();
         World.Publish(new messages.SceneChanging());
-        var cleared = World.Count();
         World.Publish(messages.LockPlayerControl.Unlock); // otherwise the timed entry locking will be ignored
         game.LoadScene(targetScene);
-        Console.WriteLine($"Entity count before: {prevCount} cleared: {cleared} loaded: {World.Count()}");
         World.Publish(new messages.PlayerEntered(FindEntryTrigger()));
         entity.Set(components.GameFlow.Normal);
     }

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -1,0 +1,84 @@
+﻿namespace zzre.game.systems;
+using System;
+using System.Linq;
+using DefaultEcs.System;
+using zzio.scn;
+
+[PauseDuring(PauseTrigger.UIScreen)]
+public partial class Doorway : ISystem<float>
+{
+    private readonly DefaultEcs.World ecsWorld;
+    private readonly Game game;
+    private readonly IDisposable doorwayTriggerDisposable;
+
+    private string targetScene = "";
+    private int targetEntry;
+    private float fadeOffTime; // just a placeholder, will be removed after actual fade off exists
+
+    public bool IsEnabled { get; set; } = true;
+
+    public Doorway(ITagContainer diContainer)
+    {
+        ecsWorld = diContainer.GetTag<DefaultEcs.World>();
+        game = diContainer.GetTag<Game>();
+        doorwayTriggerDisposable = ecsWorld.SubscribeComponentAdded<components.ActiveTrigger>(HandleActiveTrigger);
+    }
+
+    public void Dispose()
+    {
+        doorwayTriggerDisposable?.Dispose();
+    }
+
+    private void HandleActiveTrigger(in DefaultEcs.Entity entity, in components.ActiveTrigger value)
+    {
+        if (!IsEnabled)
+            return;
+
+        var trigger = entity.Get<Trigger>();
+        if (trigger.type != TriggerType.Doorway)
+            return;
+
+        targetScene = $"sc_{trigger.ii3}";
+        targetEntry = (int)trigger.ii2;
+        fadeOffTime = 0.6f;
+        ecsWorld.Publish(messages.LockPlayerControl.Forever);
+        // TODO: Add fade off during scene changes
+        // TODO: Fade off music and ambient sounds during scene changes
+    }
+
+    public void Update(float elapsedTime)
+    {
+        if (fadeOffTime <= 0f)
+            return;
+        fadeOffTime -= elapsedTime;
+        if (fadeOffTime > 0f)
+            return;
+
+        ecsWorld.Publish(new messages.SceneChanging());
+        game.LoadScene(targetScene);
+        ecsWorld.Publish(new messages.PlayerEntered(FindEntryTrigger()));
+    }
+
+    private Trigger? TryFindTrigger(TriggerType type, int ii1 = -1)
+    {
+        var triggerEntity = ecsWorld
+            .GetEntities()
+            .With((in Trigger t) => t.type == type && (ii1 < 0 || t.ii1 == ii1))
+            .AsEnumerable()
+            .FirstOrDefault();
+        return triggerEntity == default
+            ? null
+            : triggerEntity.Get<Trigger>();
+    }
+
+    private Trigger FindEntryTrigger() => (targetEntry < 0
+        ? (TryFindTrigger(TriggerType.SingleplayerStartpoint)
+        ?? TryFindTrigger(TriggerType.SavePoint)
+        ?? TryFindTrigger(TriggerType.MultiplayerStartpoint))
+
+        : TryFindTrigger(TriggerType.Doorway, targetEntry)
+        ?? TryFindTrigger(TriggerType.Elevator, targetEntry)
+        ?? TryFindTrigger(TriggerType.RuneTarget, targetEntry))
+
+        ?? throw new System.IO.InvalidDataException($"Scene {targetScene} does not have suitable entry trigger for {targetEntry}");
+}

--- a/zzre/game/systems/gameflow/Doorway.cs
+++ b/zzre/game/systems/gameflow/Doorway.cs
@@ -59,6 +59,7 @@ public partial class Doorway : AEntitySetSystem<float>
         var prevCount = World.Count();
         World.Publish(new messages.SceneChanging());
         Console.WriteLine($"Entity count before: {prevCount} after {World.Count()}");
+        World.Publish(messages.LockPlayerControl.Unlock); // otherwise the timed entry locking will be ignored
         game.LoadScene(targetScene);
         World.Publish(new messages.PlayerEntered(FindEntryTrigger()));
         entity.Set(components.GameFlow.Normal);

--- a/zzre/game/systems/gameflow/GotCard.cs
+++ b/zzre/game/systems/gameflow/GotCard.cs
@@ -22,7 +22,7 @@ public partial class GotCard : AEntitySetSystem<float>
         base.Dispose();
         gotCardDisposable?.Dispose();
     }
-
+     
     private void HandleGotCard(in messages.GotCard message)
     {
         lastMessage = message;

--- a/zzre/game/systems/model/BehaviourCollectablePhysics.cs
+++ b/zzre/game/systems/model/BehaviourCollectablePhysics.cs
@@ -21,13 +21,12 @@ namespace zzre.game.systems
         private const float MinBonkYSpeed = 0.3f;
 
         private readonly rendering.Camera camera;
-        private readonly WorldCollider worldCollider;
         private readonly IDisposable addedSubscription;
+        private WorldCollider? worldCollider;
 
         public BehaviourCollectablePhysics(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: false)
         {
             camera = diContainer.GetTag<rendering.Camera>();
-            worldCollider = diContainer.GetTag<WorldCollider>();
             addedSubscription = World.SubscribeComponentAdded<components.behaviour.CollectablePhysics>(HandleComponentAdded);
         }
 
@@ -67,6 +66,7 @@ namespace zzre.game.systems
             var newPos = oldPos + elapsedTime * curVelocity - Vector3.UnitY * YOffset;
             physics.YVelocity -= elapsedTime * Gravity;
 
+            worldCollider ??= World.Get<WorldCollider>();
             var intersection = worldCollider.Cast(new Line(oldPos, newPos));
             if (intersection.HasValue)
             {

--- a/zzre/game/systems/model/ModelLoader.cs
+++ b/zzre/game/systems/model/ModelLoader.cs
@@ -124,9 +124,9 @@ namespace zzre.game.systems
             entity.Set(new List<materials.BaseModelInstancedMaterial>(clumpBuffers.SubMeshes.Count));
 
             var rwMaterials = clumpBuffers.SubMeshes.Select(sm => sm.Material);
-            foreach (var rwMaterial in rwMaterials)
-                entity.Set(ManagedResource<materials.BaseModelInstancedMaterial>.Create(
-                    new resources.ClumpMaterialInfo(renderType, rwMaterial)));
+            entity.Set(ManagedResource<materials.BaseModelInstancedMaterial>.Create(rwMaterials
+                .Select(rwMaterial => new resources.ClumpMaterialInfo(renderType, rwMaterial))
+                .ToArray()));
         }
 
         private static void SetCollider(DefaultEcs.Entity entity)

--- a/zzre/game/systems/model/ModelLoader.cs
+++ b/zzre/game/systems/model/ModelLoader.cs
@@ -14,12 +14,14 @@ namespace zzre.game.systems
     {
         private readonly ITagContainer diContainer;
         private readonly DefaultEcs.World ecsWorld;
+        private readonly IDisposable sceneChangingSubscription;
         private readonly IDisposable sceneLoadSubscription;
 
         public ModelLoader(ITagContainer diContainer)
         {
             this.diContainer = diContainer;
             ecsWorld = diContainer.GetTag<DefaultEcs.World>();
+            sceneChangingSubscription = ecsWorld.Subscribe<messages.SceneChanging>(HandleSceneChanging);
             sceneLoadSubscription = ecsWorld.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
         }
 
@@ -34,6 +36,11 @@ namespace zzre.game.systems
         public void Update(float state)
         {
         }
+
+        private void HandleSceneChanging(in messages.SceneChanging _) => ecsWorld
+            .GetEntities()
+            .With<components.RenderOrder>()
+            .DisposeAll();
 
         private void HandleSceneLoaded(in messages.SceneLoaded message)
         {

--- a/zzre/game/systems/model/ModelRenderer.cs
+++ b/zzre/game/systems/model/ModelRenderer.cs
@@ -26,15 +26,15 @@ namespace zzre.game.systems
                 Count = count;
             }
 
-            public ClumpCount Increment() => new ClumpCount(Clump, Materials, Count + 1);
+            public ClumpCount Increment() => new(Clump, Materials, Count + 1);
         }
 
         private readonly ITagContainer diContainer;
         private readonly IDisposable sceneLoadedSubscription;
         private readonly components.RenderOrder responsibility;
 
-        private readonly List<ClumpCount> clumpCounts = new List<ClumpCount>();
-        private readonly List<ModelInstance> instances = new List<ModelInstance>();
+        private readonly List<ClumpCount> clumpCounts = new();
+        private readonly List<ModelInstance> instances = new();
         private DeviceBuffer? instanceBuffer; // not owned
         private uint instanceStart;
 
@@ -142,6 +142,10 @@ namespace zzre.game.systems
                 cl.PopDebugGroup();
             }
             cl.PopDebugGroup();
+
+            for (int i = 0; i < clumpCounts.Count; i++)
+                clumpCounts[i] = default;
+            clumpCounts.Clear();
         }
     }
 }

--- a/zzre/game/systems/model/ModelRenderer.cs
+++ b/zzre/game/systems/model/ModelRenderer.cs
@@ -59,8 +59,8 @@ namespace zzre.game.systems
             var totalCount = MultiMap.Keys.Sum(key => MultiMap.Count(key));
             instanceBuffer = modelInstanceBuffer.DeviceBuffer;
             instanceStart = modelInstanceBuffer.Reserve(totalCount);
-            clumpCounts.Capacity = MultiMap.Keys.Count();
-            instances.Capacity = totalCount;
+            clumpCounts.EnsureCapacity(MultiMap.Keys.Count());
+            instances.EnsureCapacity(totalCount);
         }
 
         [WithPredicate]

--- a/zzre/game/systems/npc/NPC.cs
+++ b/zzre/game/systems/npc/NPC.cs
@@ -12,6 +12,7 @@ namespace zzre.game.systems
         private const float GroundFromOffset = 1f;
         private const float GroundToOffset = -7f;
 
+        private readonly IDisposable sceneChangingSubscription;
         private readonly IDisposable sceneLoadSubscription;
         private readonly IDisposable setNpcModifierSubscription;
         private readonly zzio.db.MappedDB mappedDB;
@@ -19,6 +20,7 @@ namespace zzre.game.systems
         public NPC(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
             mappedDB = diContainer.GetTag<zzio.db.MappedDB>();
+            sceneChangingSubscription = World.Subscribe<messages.SceneChanging>(HandleSceneChanging);
             sceneLoadSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             setNpcModifierSubscription = World.Subscribe<zzio.GSModSetNPCModifier>(HandleSetNpcModifier);
         }
@@ -29,6 +31,8 @@ namespace zzre.game.systems
             sceneLoadSubscription.Dispose();
             setNpcModifierSubscription.Dispose();
         }
+
+        private void HandleSceneChanging(in messages.SceneChanging _) => Set.DisposeAll();
 
         private void HandleSceneLoaded(in messages.SceneLoaded message)
         {

--- a/zzre/game/systems/npc/NPC.cs
+++ b/zzre/game/systems/npc/NPC.cs
@@ -14,14 +14,10 @@ namespace zzre.game.systems
 
         private readonly IDisposable sceneLoadSubscription;
         private readonly IDisposable setNpcModifierSubscription;
-        private readonly WorldCollider worldCollider;
-        private readonly Scene scene;
         private readonly zzio.db.MappedDB mappedDB;
 
         public NPC(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
-            worldCollider = diContainer.GetTag<WorldCollider>();
-            scene = diContainer.GetTag<Scene>();
             mappedDB = diContainer.GetTag<zzio.db.MappedDB>();
             sceneLoadSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
             setNpcModifierSubscription = World.Subscribe<zzio.GSModSetNPCModifier>(HandleSetNpcModifier);
@@ -47,6 +43,7 @@ namespace zzre.game.systems
             foreach (var trigger in triggers.Where(t => t.Get<Trigger>().ii2 >= MaxEnabledII2))
                 trigger.Disable();
 
+            var scene = message.Scene;
             foreach (var trigger in scene.triggers.Where(t => t.type == TriggerType.NpcStartpoint && t.ii2 < MaxEnabledII2))
             {
                 var entity = World.CreateEntity();
@@ -96,7 +93,7 @@ namespace zzre.game.systems
                     entity.Set(components.NPCType.Biped);
                 var npcType = entity.Get<components.NPCType>();
                 if (npcType != components.NPCType.Flying && entity.Has<Sphere>())
-                    PutOnGround(entity);
+                    World.Publish(new messages.CreaturePlaceToGround(entity));
 
                 // TODO: Add SelectableNPC for Biped, Item, Flying
                 // TODO: Add Pixie behaviour
@@ -108,17 +105,6 @@ namespace zzre.game.systems
         [Update]
         private void Update(float elapsedTime, ref components.NPCState npc)
         {
-        }
-
-        private void PutOnGround(DefaultEcs.Entity entity)
-        {
-            var collider = entity.Get<Sphere>();
-            var location = entity.Get<Location>();
-            var cast = worldCollider.Cast(new Line(
-                location.LocalPosition + Vector3.UnitY * GroundFromOffset,
-                location.LocalPosition + Vector3.UnitY * GroundToOffset));
-            if (cast != null)
-                location.LocalPosition = cast.Value.Point + Vector3.UnitY * collider.Radius / 2f;
         }
 
         private void HandleSetNpcModifier(in zzio.GSModSetNPCModifier gsmod)

--- a/zzre/game/systems/npc/NPCLookAtTrigger.cs
+++ b/zzre/game/systems/npc/NPCLookAtTrigger.cs
@@ -8,11 +8,8 @@ namespace zzre.game.systems
     [PauseDuring(PauseTrigger.UIScreen)]
     public partial class NPCLookAtTrigger : AEntitySetSystem<float>
     {
-        private readonly Scene scene;
-
         public NPCLookAtTrigger(ITagContainer diContainer) : base(diContainer.GetTag<DefaultEcs.World>(), CreateEntityContainer, useBuffer: true)
         {
-            scene = diContainer.GetTag<Scene>();
         }
 
         [WithPredicate]
@@ -35,9 +32,16 @@ namespace zzre.game.systems
                 return;
             }
 
-            var triggerIdx = lookAt.TriggerIdx;
-            var trigger = scene.triggers.First(t => t.idx == triggerIdx);
-            puppet.TargetDirection = Vector3.Normalize(trigger.pos - location.LocalPosition);
+            if (lookAt.Trigger == null)
+            {
+                var triggerIdx = lookAt.TriggerIdx;
+                lookAt.Trigger = World.GetEntities()
+                    .With((in Trigger t) => t.idx == triggerIdx)
+                    .AsEnumerable()
+                    .First()
+                    .Get<Trigger>();
+            }
+            puppet.TargetDirection = Vector3.Normalize(lookAt.Trigger.pos - location.LocalPosition);
 
             // TODO: Add ActorHeadIK behavior for LookAtTrigger
         }

--- a/zzre/game/systems/npc/NPCMovementBase.cs
+++ b/zzre/game/systems/npc/NPCMovementBase.cs
@@ -15,7 +15,6 @@ namespace zzre.game.systems
 
         private readonly Lazy<Location> playerLocationLazy;
         private readonly IDisposable sceneLoadedSubscription;
-        protected readonly Scene scene;
         protected IReadOnlyDictionary<int, Trigger> waypointById = new Dictionary<int, Trigger>();
         protected IReadOnlyDictionary<int, Trigger> waypointByIdx = new Dictionary<int, Trigger>();
         protected ILookup<int, Trigger> waypointsByCategory = Enumerable.Empty<Trigger>().ToLookup(t => 0);
@@ -27,7 +26,6 @@ namespace zzre.game.systems
         {
             var game = diContainer.GetTag<Game>();
             playerLocationLazy = new Lazy<Location>(() => game.PlayerEntity.Get<Location>());
-            scene = diContainer.GetTag<Scene>();
             sceneLoadedSubscription = World.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
         }
 
@@ -37,8 +35,9 @@ namespace zzre.game.systems
             sceneLoadedSubscription.Dispose();
         }
 
-        private void HandleSceneLoaded(in messages.SceneLoaded _)
+        private void HandleSceneLoaded(in messages.SceneLoaded message)
         {
+            var scene = message.Scene;
             var waypoints = scene.triggers.Where(t => t.type == TriggerType.Waypoint).ToArray();
             waypointById = waypoints
                 .GroupBy(wp => (int)wp.ii1)

--- a/zzre/game/systems/npc/NPCScript.Execute.cs
+++ b/zzre/game/systems/npc/NPCScript.Execute.cs
@@ -33,6 +33,7 @@ namespace zzre.game.systems
         private const string CmdCreateDynamicItems = "_";
         private const string CmdRevive = "b";
         private const string CmdLookAtTrigger = "c";
+        private const string CmdPlaySound = "e";
 
         protected override OpReturn Execute(in DefaultEcs.Entity entity, ref components.ScriptExecution script, RawInstruction instruction)
         {
@@ -193,6 +194,11 @@ namespace zzre.game.systems
                     duration = int.Parse(args[0]);
                     triggerI = int.Parse(args[1]);
                     LookAtTrigger(entity, duration, triggerI);
+                    return OpReturn.Continue;
+
+                case CmdPlaySound:
+                    var id = int.Parse(args[0]);
+                    PlaySound(entity, id);
                     return OpReturn.Continue;
 
                 default: return OpReturn.UnknownInstruction;

--- a/zzre/game/systems/npc/NPCScript.cs
+++ b/zzre/game/systems/npc/NPCScript.cs
@@ -288,5 +288,10 @@ namespace zzre.game.systems
             entity.Set(new components.NPCLookAtTrigger(triggerI, actualDuration));
             entity.Set(components.NPCState.LookAtTrigger);
         }
+
+        private void PlaySound(DefaultEcs.Entity entity, int soundId)
+        {
+            Console.WriteLine("Warning: unimplemented NPC instruction \"playSound\"");
+        }
     }
 }

--- a/zzre/game/systems/npc/NPCScript.cs
+++ b/zzre/game/systems/npc/NPCScript.cs
@@ -17,7 +17,6 @@ namespace zzre.game.systems
 
         private readonly IDisposable executeScriptSubscription;
         private readonly Game game;
-        private readonly Scene scene;
         private readonly MappedDB db;
         private Location playerLocation => playerLocationLazy.Value;
         private readonly Lazy<Location> playerLocationLazy;
@@ -25,7 +24,6 @@ namespace zzre.game.systems
         public NPCScript(ITagContainer diContainer) : base(diContainer, CreateEntityContainer)
         {
             game = diContainer.GetTag<Game>();
-            scene = diContainer.GetTag<Scene>();
             db = diContainer.GetTag<MappedDB>();
             playerLocationLazy = new Lazy<Location>(() => game.PlayerEntity.Get<Location>());
             executeScriptSubscription = World.Subscribe<messages.ExecuteNPCScript>(HandleExecuteNPCScript);

--- a/zzre/game/systems/player/PlayerControls.cs
+++ b/zzre/game/systems/player/PlayerControls.cs
@@ -46,9 +46,13 @@ namespace zzre.game.systems
 
         private void HandleLockPlayerControl(in messages.LockPlayerControl msg)
         {
-            stuckMovingForward = msg.MovingForward;
-            if (msg == messages.LockPlayerControl.Unlock || lockTimer != float.PositiveInfinity)
+            if (msg == messages.LockPlayerControl.Unlock)
+                lockTimer = 0f;
+            else if (msg.Duration > lockTimer)
+            {
                 lockTimer = msg.Duration;
+                stuckMovingForward = msg.MovingForward;
+            }
         }
 
         protected override void Update(float elapsedTime, ref components.PlayerControls component)

--- a/zzre/game/systems/player/PlayerControls.cs
+++ b/zzre/game/systems/player/PlayerControls.cs
@@ -17,6 +17,7 @@ namespace zzre.game.systems
         private readonly UI ui;
         private readonly IDisposable lockMessageSubscription;
 
+        private bool stuckMovingForward;
         private float lockTimer;
         private float jumpLockTimer;
         private bool jumpChanged;
@@ -45,6 +46,7 @@ namespace zzre.game.systems
 
         private void HandleLockPlayerControl(in messages.LockPlayerControl msg)
         {
+            stuckMovingForward = msg.MovingForward;
             if (msg == messages.LockPlayerControl.Unlock || lockTimer != float.PositiveInfinity)
                 lockTimer = msg.Duration;
         }
@@ -54,7 +56,7 @@ namespace zzre.game.systems
             lockTimer = Math.Max(0f, lockTimer - elapsedTime);
             if (IsLocked)
             {
-                component = default;
+                component = new components.PlayerControls() with { GoesForward = stuckMovingForward };
                 return;
             }
 

--- a/zzre/game/systems/player/PlayerPuppet.cs
+++ b/zzre/game/systems/player/PlayerPuppet.cs
@@ -43,7 +43,7 @@ namespace zzre.game.systems
             Animation(elapsedTime, ref puppet, physics, ref animation);
             Falling(elapsedTime, ref puppet, ref physics, ref animation);
             Idling(ref puppet, ref physics);
-            NPCComfortZone(ref physics);
+            SpeedModifier(ref physics);
             ActorTargetDirection(physics, ref puppetActorMovement);
         }
 
@@ -134,11 +134,13 @@ namespace zzre.game.systems
             }
         }
 
-        private void NPCComfortZone(ref components.HumanPhysics physics)
+        private void SpeedModifier(ref components.HumanPhysics physics)
         {
             physics.SpeedModifier = World.Has<components.ActiveNPC>()
                 ? NPCComfortZoneSpeed
-                : components.HumanPhysics.DefaultSpeedModifier;
+                : World.Get<zzio.scn.Scene>().dataset.isInterior
+                ? components.HumanPhysics.InteriorSpeedModifier
+                : components.HumanPhysics.ExteriorSpeedModifier;
         }
 
         private void ActorTargetDirection(

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -68,7 +68,7 @@ public class PlayerSpawner : ISystem<float>
         if (trigger.type == TriggerType.Doorway && trigger.colliderType == TriggerColliderType.Sphere)
             startPos += trigger.dir * trigger.radius * 1.2f;
         playerLocation.LocalPosition = startPos;
-        playerLocation.LookIn(trigger.dir);
+        // here the LookIn was removed because of a physics/animation bug.
         playerEntity.Get<components.PuppetActorMovement>().TargetDirection = trigger.dir;
         ecsWorld.Publish(new messages.CreaturePlaceToGround(playerEntity));
     }

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -75,7 +75,7 @@ public class PlayerSpawner : ISystem<float>
         if (trigger.type == TriggerType.Doorway && trigger.colliderType == TriggerColliderType.Sphere)
             startPos += trigger.dir * trigger.radius * 1.2f;
         playerLocation.LocalPosition = startPos;
-        // here the LookIn was removed because of a physics/animation bug.
+        playerLocation.LookIn(MathEx.SafeNormalize(trigger.dir with { Y = 0f }));
         playerEntity.Get<components.PuppetActorMovement>().TargetDirection = trigger.dir;
         ecsWorld.Publish(new messages.CreaturePlaceToGround(playerEntity));
 

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -71,6 +71,14 @@ public class PlayerSpawner : ISystem<float>
         // here the LookIn was removed because of a physics/animation bug.
         playerEntity.Get<components.PuppetActorMovement>().TargetDirection = trigger.dir;
         ecsWorld.Publish(new messages.CreaturePlaceToGround(playerEntity));
+
+        var isInterior = ecsWorld.Get<Scene>().dataset.isInterior;
+        if (trigger.type == TriggerType.Doorway)
+            ecsWorld.Publish(new messages.LockPlayerControl(
+                isInterior ? ControlsLockedInterior : ControlsLockedExterior,
+                MovingForward: true));
+        else
+            ecsWorld.Publish(new messages.LockPlayerControl(ControlsLockedRune, MovingForward: false));
     }
 
     private static float GetColliderSize(DefaultEcs.Entity playerEntity)

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -62,12 +62,11 @@ public class PlayerSpawner : ISystem<float>
 
     private void HandlePlayerEntered(in messages.PlayerEntered message)
     {
+        var playerLocation = playerEntity.Get<Location>();
         var trigger = message.EntryTrigger;
         var startPos = trigger.pos;
         if (trigger.type == TriggerType.Doorway && trigger.colliderType == TriggerColliderType.Sphere)
             startPos += trigger.dir * trigger.radius * 1.2f;
-
-        var playerLocation = playerEntity.Get<Location>();
         playerLocation.LocalPosition = startPos;
         playerLocation.LookIn(trigger.dir);
         playerEntity.Get<components.PuppetActorMovement>().TargetDirection = trigger.dir;

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -13,6 +13,7 @@ public class PlayerSpawner : ISystem<float>
     private readonly ITagContainer diContainer;
     private readonly zzio.Savegame savegame;
     private readonly DefaultEcs.World ecsWorld;
+    private readonly IDisposable sceneChangingSubscription;
     private readonly IDisposable sceneLoadedSubscription;
     private readonly IDisposable playerEnteredSubscription;
 
@@ -25,6 +26,7 @@ public class PlayerSpawner : ISystem<float>
         this.diContainer = diContainer;
         savegame = diContainer.GetTag<zzio.Savegame>();
         ecsWorld = diContainer.GetTag<DefaultEcs.World>();
+        sceneChangingSubscription = ecsWorld.Subscribe<messages.SceneChanging>(HandleSceneChanging);
         sceneLoadedSubscription = ecsWorld.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
         playerEnteredSubscription = ecsWorld.Subscribe<messages.PlayerEntered>(HandlePlayerEntered);
 
@@ -33,9 +35,12 @@ public class PlayerSpawner : ISystem<float>
 
     public void Dispose()
     {
+        sceneChangingSubscription.Dispose();
         sceneLoadedSubscription.Dispose();
         playerEnteredSubscription.Dispose();
     }
+
+    private void HandleSceneChanging(in messages.SceneChanging _) => playerEntity.Dispose();
 
     private void HandleSceneLoaded(in messages.SceneLoaded message)
     {

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -1,0 +1,85 @@
+﻿namespace zzre.game.systems;
+using System;
+using System.Numerics;
+using DefaultEcs.System;
+using zzio.scn;
+
+public class PlayerSpawner : ISystem<float>
+{
+    private const float ControlsLockedInterior = 1.2f;
+    private const float ControlsLockedExterior = 1.5f;
+    private const float ControlsLockedRune = 2f;
+
+    private readonly ITagContainer diContainer;
+    private readonly zzio.Savegame savegame;
+    private readonly DefaultEcs.World ecsWorld;
+    private readonly IDisposable sceneLoadedSubscription;
+    private readonly IDisposable playerEnteredSubscription;
+
+    private DefaultEcs.Entity playerEntity;
+
+    public bool IsEnabled { get; set; } = true;
+
+    public PlayerSpawner(ITagContainer diContainer)
+    {
+        this.diContainer = diContainer;
+        savegame = diContainer.GetTag<zzio.Savegame>();
+        ecsWorld = diContainer.GetTag<DefaultEcs.World>();
+        sceneLoadedSubscription = ecsWorld.Subscribe<messages.SceneLoaded>(HandleSceneLoaded);
+        playerEnteredSubscription = ecsWorld.Subscribe<messages.PlayerEntered>(HandlePlayerEntered);
+
+        ecsWorld.SetMaxCapacity<components.PlayerEntity>(1);
+    }
+
+    public void Dispose()
+    {
+        sceneLoadedSubscription.Dispose();
+        playerEnteredSubscription.Dispose();
+    }
+
+    private void HandleSceneLoaded(in messages.SceneLoaded message)
+    {
+        playerEntity = ecsWorld.CreateEntity();
+        playerEntity.Set(new Location()
+        {
+            Parent = ecsWorld.Get<Location>(),
+            LocalPosition = new Vector3(216f, 40.5f, 219f)
+        });
+        playerEntity.Set(DefaultEcs.Resource.ManagedResource<zzio.ActorExDescription>.Create("chr01"));
+        playerEntity.Set(components.Visibility.Visible);
+        playerEntity.Set<components.PlayerControls>();
+        playerEntity.Set<components.PlayerPuppet>();
+        playerEntity.Set(components.PhysicParameters.Standard);
+        playerEntity.Set(new components.NonFairyAnimation(GlobalRandom.Get));
+        playerEntity.Set<components.PuppetActorMovement>();
+        var playerColliderSize = GetColliderSize(playerEntity);
+        playerEntity.Set(new components.HumanPhysics(playerColliderSize));
+        playerEntity.Set(new Sphere(Vector3.Zero, playerColliderSize));
+        playerEntity.Set(new Inventory(diContainer, savegame));
+        playerEntity.Set(components.GameFlow.Normal); // TODO: Move GameFlow component to world instead of player entity
+        ecsWorld.Set(new components.PlayerEntity(playerEntity));
+    }
+
+    private void HandlePlayerEntered(in messages.PlayerEntered message)
+    {
+        var trigger = message.EntryTrigger;
+        var startPos = trigger.pos;
+        if (trigger.type == TriggerType.Doorway && trigger.colliderType == TriggerColliderType.Sphere)
+            startPos += trigger.dir * trigger.radius * 1.2f;
+
+        var playerLocation = playerEntity.Get<Location>();
+        playerLocation.LocalPosition = startPos;
+        playerLocation.LookIn(trigger.dir);
+        playerEntity.Get<components.PuppetActorMovement>().TargetDirection = trigger.dir;
+        ecsWorld.Publish(new messages.CreaturePlaceToGround(playerEntity));
+    }
+
+    private static float GetColliderSize(DefaultEcs.Entity playerEntity)
+    {
+        var playerActorParts = playerEntity.Get<components.ActorParts>();
+        var playerBodyClump = playerActorParts.Body.Get<ClumpBuffers>();
+        return playerBodyClump.Bounds.Size.Y;
+    }
+
+    public void Update(float state) { }
+}

--- a/zzre/game/systems/player/PlayerSpawner.cs
+++ b/zzre/game/systems/player/PlayerSpawner.cs
@@ -40,10 +40,12 @@ public class PlayerSpawner : ISystem<float>
         playerEnteredSubscription.Dispose();
     }
 
-    private void HandleSceneChanging(in messages.SceneChanging _) => playerEntity.Dispose();
+    private void HandleSceneChanging(in messages.SceneChanging _) { }
 
     private void HandleSceneLoaded(in messages.SceneLoaded message)
     {
+        if (playerEntity != default)
+            return;
         playerEntity = ecsWorld.CreateEntity();
         playerEntity.Set(new Location()
         {

--- a/zzre/game/systems/player/PlayerTriggers.cs
+++ b/zzre/game/systems/player/PlayerTriggers.cs
@@ -48,7 +48,8 @@ namespace zzre.game.systems
 
         private void HandleSceneChanging(in messages.SceneChanging _)
         {
-            npcMarker.Dispose();
+            if (npcMarker.IsAlive)
+                npcMarker.Dispose();
             npcMarker = default;
         }
 

--- a/zzre/game/systems/player/PlayerTriggers.cs
+++ b/zzre/game/systems/player/PlayerTriggers.cs
@@ -14,10 +14,11 @@ namespace zzre.game.systems
         private const float NpcMarkerDistance = 0.3f;
 
         private readonly DefaultEcs.World world;
-        private readonly DefaultEcs.Entity npcMarker;
         private readonly IZanzarahContainer zzContainer;
         private readonly PlayerControls playerControls;
         private readonly Location cameraLocation;
+        private readonly IDisposable sceneChangingDisposable;
+        private DefaultEcs.Entity npcMarker;
 
         public bool IsEnabled { get; set; } = true;
         public bool IsMarkerActive => npcMarker.Has<components.Visibility>();
@@ -36,23 +37,19 @@ namespace zzre.game.systems
             cameraLocation = diContainer.GetTag<rendering.Camera>().Location;
             playerLocationLazy = new Lazy<Location>(() => game.PlayerEntity.Get<Location>());
 
-            npcMarker = world.CreateEntity();
-            npcMarker.Set(new Location());
-            npcMarker.Set(new components.behaviour.Rotate(Vector3.UnitY, 90f));
-            npcMarker.Set(ManagedResource<ClumpBuffers>.Create(
-                new resources.ClumpInfo(resources.ClumpType.Model, "marker.dff")));
-            ModelLoader.LoadMaterialsFor(npcMarker,
-                zzio.scn.FOModelRenderType.Solid,
-                zzio.IColor.Green,
-                new zzio.SurfaceProperties(1f, 1f, 1f));
-            var materials = npcMarker.Get<List<materials.BaseModelInstancedMaterial>>();
-            foreach (var material in materials)
-                material.Uniforms.Ref.vertexColorFactor = 1f;
+            sceneChangingDisposable = world.Subscribe<messages.SceneChanging>(HandleSceneChanging);
         }
 
         public void Dispose()
         {
             zzContainer.OnMouseDown -= HandleMouseDown;
+            sceneChangingDisposable.Dispose();
+        }
+
+        private void HandleSceneChanging(in messages.SceneChanging _)
+        {
+            npcMarker.Dispose();
+            npcMarker = default;
         }
 
         private void HandleMouseDown(Veldrid.MouseButton button, Vector2 _)
@@ -68,6 +65,7 @@ namespace zzre.game.systems
         {
             // TODO: Add sound effect for looking at triggers
 
+            EnsureNpcMarker();
             if (TryGetTriggerableNPC(out var npc))
             {
                 // TODO: Fix marker distance for flying-type NPCs
@@ -100,6 +98,24 @@ namespace zzre.game.systems
             var cameraDir = cameraLocation.GlobalForward with { Y = 0.001f };
             var dirDistance = Vector3.Distance(Vector3.Normalize(playerToNpc), Vector3.Normalize(cameraDir));
             return dirDistance < MaxNpcDirDistance;
+        }
+
+        private void EnsureNpcMarker()
+        {
+            if (npcMarker.IsAlive)
+                return;
+            npcMarker = world.CreateEntity();
+            npcMarker.Set(new Location());
+            npcMarker.Set(new components.behaviour.Rotate(Vector3.UnitY, 90f));
+            npcMarker.Set(ManagedResource<ClumpBuffers>.Create(
+                new resources.ClumpInfo(resources.ClumpType.Model, "marker.dff")));
+            ModelLoader.LoadMaterialsFor(npcMarker,
+                zzio.scn.FOModelRenderType.Solid,
+                zzio.IColor.Green,
+                new zzio.SurfaceProperties(1f, 1f, 1f));
+            var materials = npcMarker.Get<List<materials.BaseModelInstancedMaterial>>();
+            foreach (var material in materials)
+                material.Uniforms.Ref.vertexColorFactor = 1f;
         }
     }
 }

--- a/zzre/game/systems/player/Savegame.cs
+++ b/zzre/game/systems/player/Savegame.cs
@@ -12,7 +12,6 @@ namespace zzre.game.systems
         public bool IsEnabled { get; set; } = true;
 
         private readonly DefaultEcs.World world;
-        private readonly Scene scene;
         private readonly zzio.Savegame savegame;
         private readonly IDisposable disableAttackTriggerDisposable;
         private readonly IDisposable removeItemDisposable;
@@ -23,10 +22,11 @@ namespace zzre.game.systems
         private readonly IDisposable setNpcModifierDisposable;
         private readonly IDisposable gsmodForSceneDisposable;
 
+        private uint CurSceneID => world.Get<Scene>().dataset.sceneId;
+
         public Savegame(ITagContainer diContainer)
         {
             world = diContainer.GetTag<DefaultEcs.World>();
-            scene = diContainer.GetTag<Scene>();
             savegame = diContainer.GetTag<zzio.Savegame>();
             disableAttackTriggerDisposable = world.Subscribe<GSModDisableAttackTrigger>(HandleDisableAttackTrigger);
             removeItemDisposable = world.Subscribe<GSModRemoveItem>(HandleRemoveItem);
@@ -58,11 +58,11 @@ namespace zzre.game.systems
         private void HandleSetTrigger(in GSModSetTrigger message) => HandleGSModForThisScene(message);
         private void HandleSetNpcModifier(in GSModSetNPCModifier message) => HandleGSModForThisScene(message);
 
-        private void HandleGSModForThisScene(IGameStateMod gsMod) => savegame.Add($"sc_{scene.dataset.sceneId}", gsMod);
+        private void HandleGSModForThisScene(IGameStateMod gsMod) => savegame.Add($"sc_{CurSceneID}", gsMod);
 
         private void HandleGSModForScene(in messages.GSModForScene message)
         {
-            if (message.SceneId != scene.dataset.sceneId)
+            if (message.SceneId != CurSceneID)
             {
                 savegame.Add($"sc_{message.SceneId}", message.Mod);
                 return;

--- a/zzre/game/systems/player/Savegame.cs
+++ b/zzre/game/systems/player/Savegame.cs
@@ -13,6 +13,7 @@ namespace zzre.game.systems
 
         private readonly DefaultEcs.World world;
         private readonly zzio.Savegame savegame;
+        private readonly IDisposable playerEnteredDisposable;
         private readonly IDisposable disableAttackTriggerDisposable;
         private readonly IDisposable removeItemDisposable;
         private readonly IDisposable changeNpcStateDisposable;
@@ -28,6 +29,7 @@ namespace zzre.game.systems
         {
             world = diContainer.GetTag<DefaultEcs.World>();
             savegame = diContainer.GetTag<zzio.Savegame>();
+            playerEnteredDisposable = world.Subscribe<messages.PlayerEntered>(HandlePlayerEntered);
             disableAttackTriggerDisposable = world.Subscribe<GSModDisableAttackTrigger>(HandleDisableAttackTrigger);
             removeItemDisposable = world.Subscribe<GSModRemoveItem>(HandleRemoveItem);
             changeNpcStateDisposable = world.Subscribe<GSModChangeNPCState>(HandleChangeNpcState);
@@ -40,6 +42,7 @@ namespace zzre.game.systems
 
         public void Dispose()
         {
+            playerEnteredDisposable.Dispose();
             disableAttackTriggerDisposable.Dispose();
             removeItemDisposable.Dispose();
             changeNpcStateDisposable.Dispose();
@@ -48,6 +51,12 @@ namespace zzre.game.systems
             setTriggerDisposable.Dispose();
             setNpcModifierDisposable.Dispose();
             gsmodForSceneDisposable.Dispose();
+        }
+
+        private void HandlePlayerEntered(in messages.PlayerEntered message)
+        {
+            savegame.sceneId = (int)CurSceneID;
+            savegame.entryId = (int)message.EntryTrigger.idx;
         }
 
         private void HandleDisableAttackTrigger(in GSModDisableAttackTrigger message) => HandleGSModForThisScene(message);

--- a/zzre/rendering/ModelInstanceBuffer.cs
+++ b/zzre/rendering/ModelInstanceBuffer.cs
@@ -29,6 +29,8 @@ namespace zzre.rendering
             DeviceBuffer.Dispose();
         }
 
+        public void Clear() => FreeCount = TotalCount;
+
         public uint Reserve(int count)
         {
             if (count > FreeCount)

--- a/zzre/rendering/WorldRenderer.cs
+++ b/zzre/rendering/WorldRenderer.cs
@@ -48,21 +48,34 @@ namespace zzre.rendering
         {
             base.DisposeManaged();
             diContainer.GetTag<LocationBuffer>().Remove(locationRange);
+            DisposeMaterials();
+        }
+
+        private void DisposeMaterials()
+        {
+            var textureLoader = diContainer.GetTag<IAssetLoader<Texture>>();
             foreach (var material in materials)
+            {
+                if (textureLoader is not CachedAssetLoader<Texture>)
+                {
+                    material.MainTexture.Texture?.Dispose();
+                    material.Sampler.Sampler?.Dispose();
+                }
                 material.Dispose();
+            }
+            materials = Array.Empty<ModelStandardMaterial>();
         }
 
         private void LoadMaterials()
         {
-            foreach (var material in materials)
-                material.Dispose();
-            if (worldBuffers == null)
-                return;
-
             var textureBase = new FilePath("resources/textures/worlds");
             var textureLoader = diContainer.GetTag<IAssetLoader<Texture>>();
             var camera = diContainer.GetTag<Camera>();
 
+            DisposeMaterials();
+
+            if (worldBuffers == null)
+                return;
             materials = new ModelStandardMaterial[worldBuffers.Materials.Count];
             foreach (var (rwMaterial, index) in worldBuffers.Materials.Indexed())
             {


### PR DESCRIPTION
Some bigger structural changes are necessary, as we will reuse the game at least for overworld changes. Whether or not fights will also reuse or create a new game instance is not decided yet.

- [x] Make scene mutable over game lifetime
- [x] Clear scene message
- [x] Spawn player at entry trigger
- [x] Reset human physics and ignore clumps
- [x] Reset camera
- [x] Lock controls moving forward
- [x] Reset overworld fairy
- [x] Set new entry trigger id (for local teleporters)
- [x] Clear active NPC
- [x] Reset game flow
- [x] Fix physics bug related to setting initial rotation of amy
- [x] Fix doors disappearing after reentering
- [x] Fix memory leak (partly postponed to #180)
- [x] Fix Amy sometimes not walking forward after transition

Postponed steps (create TODO issue at merge time):
- [x] Handle actor head IK
- [x] Save savegame
- [x] Investigate updating active trigger without triggering at scene change
- [x] Create elemental lock effects
- [x] Create collection wizforms
- [x] Show hot scene warning
- [x] Show scene name notification