### PR TITLE
UI: add (boilerplate) fairy book & map menus

### DIFF
--- a/zzre/game/UI.cs
+++ b/zzre/game/UI.cs
@@ -57,6 +57,7 @@ public class UI : BaseDisposable, ITagContainer
             new systems.ui.ScrDeck(this),
             new systems.ui.ScrRuneMenu(this),
             new systems.ui.ScrBookMenu(this),
+            new systems.ui.ScrMapMenu(this),
             new systems.ui.ScrGotCard(this),
             new systems.ui.ScrNotification(this),
             new systems.ui.ButtonTiles(this),

--- a/zzre/game/UI.cs
+++ b/zzre/game/UI.cs
@@ -56,6 +56,7 @@ public class UI : BaseDisposable, ITagContainer
             new systems.ui.Cursor(this),
             new systems.ui.ScrDeck(this),
             new systems.ui.ScrRuneMenu(this),
+            new systems.ui.ScrBookMenu(this),
             new systems.ui.ScrGotCard(this),
             new systems.ui.ScrNotification(this),
             new systems.ui.ButtonTiles(this),

--- a/zzre/game/components/ui/ScrBookMenu.cs
+++ b/zzre/game/components/ui/ScrBookMenu.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace zzre.game.components.ui;
+
+public struct ScrBookMenu
+{
+    public Inventory Inventory;
+}

--- a/zzre/game/components/ui/ScrMapMenu.cs
+++ b/zzre/game/components/ui/ScrMapMenu.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+
+namespace zzre.game.components.ui;
+
+public struct ScrMapMenu
+{
+    public Inventory Inventory;
+}

--- a/zzre/game/messages/ui/OpenScreen.cs
+++ b/zzre/game/messages/ui/OpenScreen.cs
@@ -5,5 +5,6 @@ public record struct GameScreenClosed;
 
 public record struct OpenDeck;
 public record struct OpenRuneMenu;
+public record struct OpenBookMenu;
 
 public record struct OpenGotCard(zzio.UID UID, int Amount);

--- a/zzre/game/messages/ui/OpenScreen.cs
+++ b/zzre/game/messages/ui/OpenScreen.cs
@@ -6,5 +6,6 @@ public record struct GameScreenClosed;
 public record struct OpenDeck;
 public record struct OpenRuneMenu;
 public record struct OpenBookMenu;
+public record struct OpenMapMenu;
 
 public record struct OpenGotCard(zzio.UID UID, int Amount);

--- a/zzre/game/systems/player/PlayerControls.cs
+++ b/zzre/game/systems/player/PlayerControls.cs
@@ -16,7 +16,7 @@ public class PlayerControls : AComponentSystem<float, components.PlayerControls>
     // private const Key PauseKey = Key.F1;
     private const Key RuneMenuKey = Key.F2;
     private const Key BookMenuKey = Key.F3;
-    // private const Key MapMenuKey = Key.F4;
+    private const Key MapMenuKey = Key.F4;
     private const Key DeckMenuKey = Key.F5;
     // private const Key EscapeKey = Key.Escape;
     private readonly IZanzarahContainer zzContainer;
@@ -106,7 +106,7 @@ public class PlayerControls : AComponentSystem<float, components.PlayerControls>
                 case MenuKey: ui.Publish<messages.ui.OpenDeck>(); break;
                 case RuneMenuKey: ui.Publish<messages.ui.OpenRuneMenu>(); break;
                 case BookMenuKey: ui.Publish<messages.ui.OpenBookMenu>(); break;
-                // case MapMenuKey: ui.Publish<messages.ui.OpenMapMenu>(); break;
+                case MapMenuKey: ui.Publish<messages.ui.OpenMapMenu>(); break;
                 case DeckMenuKey: ui.Publish<messages.ui.OpenDeck>(); break;
             }
         }

--- a/zzre/game/systems/player/PlayerControls.cs
+++ b/zzre/game/systems/player/PlayerControls.cs
@@ -15,7 +15,7 @@ public class PlayerControls : AComponentSystem<float, components.PlayerControls>
     private const Key MenuKey = Key.Enter;
     // private const Key PauseKey = Key.F1;
     private const Key RuneMenuKey = Key.F2;
-    // private const Key BookMenuKey = Key.F3;
+    private const Key BookMenuKey = Key.F3;
     // private const Key MapMenuKey = Key.F4;
     private const Key DeckMenuKey = Key.F5;
     // private const Key EscapeKey = Key.Escape;
@@ -105,7 +105,7 @@ public class PlayerControls : AComponentSystem<float, components.PlayerControls>
             {
                 case MenuKey: ui.Publish<messages.ui.OpenDeck>(); break;
                 case RuneMenuKey: ui.Publish<messages.ui.OpenRuneMenu>(); break;
-                // case BookMenuKey: ui.Publish<messages.ui.OpenBookMenu>(); break;
+                case BookMenuKey: ui.Publish<messages.ui.OpenBookMenu>(); break;
                 // case MapMenuKey: ui.Publish<messages.ui.OpenMapMenu>(); break;
                 case DeckMenuKey: ui.Publish<messages.ui.OpenDeck>(); break;
             }

--- a/zzre/game/systems/ui/ScrBookMenu.cs
+++ b/zzre/game/systems/ui/ScrBookMenu.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Veldrid;
+using zzio;
+using zzio.db;
+using static zzre.game.systems.ui.InGameScreen;
+
+namespace zzre.game.systems.ui;
+
+public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, messages.ui.OpenBookMenu>
+{
+    private readonly MappedDB db;
+
+    public ScrBookMenu(ITagContainer diContainer) : base(diContainer, BlockFlags.All)
+    {
+        db = diContainer.GetTag<MappedDB>();
+        OnElementDown += HandleElementDown;
+    }
+
+    protected override void HandleOpen(in messages.ui.OpenBookMenu message)
+    {
+        var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
+        if (!inventory.Contains(StdItemId.FairyBook))
+            return;
+
+        var entity = World.CreateEntity();
+        entity.Set<components.ui.ScrBookMenu>();
+        ref var bookMenu = ref entity.Get<components.ui.ScrBookMenu>();
+        bookMenu.Inventory = inventory;
+
+        preload.CreateImage(entity)
+            .With(-new Vector2(320, 240))
+            .WithBitmap("col000")
+            .WithRenderOrder(1)
+            .Build();
+
+        preload.CreateTooltipTarget(entity)
+            .With(new Vector2(-320 + 11, -240 + 11))
+            .WithText("{205} - ")
+            .Build();
+
+        CreateTopButtons(preload, entity, inventory, IDOpenFairybook);
+    }
+
+    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.ui.ScrBookMenu bookMenu)
+    {
+        base.Update(timeElapsed, entity, ref bookMenu);
+    }
+
+    private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId id)
+    {
+        var bookMenuEntity = Set.GetEntities()[0];
+        if (id == IDOpenDeck)
+        {
+            bookMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenDeck>();
+        }
+        else if (id == IDOpenRunes)
+        {
+            bookMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
+        }
+        else if (id == IDClose)
+            bookMenuEntity.Dispose();
+    }
+
+    protected override void HandleKeyDown(Key key)
+    {
+        var bookMenuEntity = Set.GetEntities()[0];
+        base.HandleKeyDown(key);
+        if (key == Key.F2) {
+            bookMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
+        }
+        // if (key == Key.F4) {
+        //     runeMenuEntity.Dispose();
+        //     zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        // }
+        if (key == Key.F5) {
+            bookMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenDeck>();
+        }
+        if (key == Key.Enter || key == Key.Escape || key == Key.F3)
+            Set.DisposeAll();
+    }
+}

--- a/zzre/game/systems/ui/ScrDeck.cs
+++ b/zzre/game/systems/ui/ScrDeck.cs
@@ -553,6 +553,11 @@ public partial class ScrDeck : BaseScreen<components.ui.ScrDeck, messages.ui.Ope
             deckEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
         }
+        else if (id == IDOpenFairybook)
+        {
+            deckEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
+        }
         else if (id == IDClose)
             deckEntity.Dispose();
     }
@@ -587,10 +592,10 @@ public partial class ScrDeck : BaseScreen<components.ui.ScrDeck, messages.ui.Ope
             deckEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
         }
-        // if (key == Key.F3) {
-        //     deckEntity.Dispose();
-        //     zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
-        // }
+        if (key == Key.F3) {
+            deckEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
+        }
         // if (key == Key.F4) {
         //     deckEntity.Dispose();
         //     zanzarah.UI.Publish<messages.ui.OpenMapMenu>();

--- a/zzre/game/systems/ui/ScrDeck.cs
+++ b/zzre/game/systems/ui/ScrDeck.cs
@@ -558,6 +558,11 @@ public partial class ScrDeck : BaseScreen<components.ui.ScrDeck, messages.ui.Ope
             deckEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
+        else if (id == IDOpenMap)
+        {
+            deckEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        }
         else if (id == IDClose)
             deckEntity.Dispose();
     }
@@ -596,10 +601,10 @@ public partial class ScrDeck : BaseScreen<components.ui.ScrDeck, messages.ui.Ope
             deckEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
-        // if (key == Key.F4) {
-        //     deckEntity.Dispose();
-        //     zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
-        // }
+        if (key == Key.F4) {
+            deckEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        }
         if (key == Key.Enter || key == Key.Escape || key == Key.F5)
             Set.DisposeAll();
     }

--- a/zzre/game/systems/ui/ScrMapMenu.cs
+++ b/zzre/game/systems/ui/ScrMapMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -9,30 +9,30 @@ using static zzre.game.systems.ui.InGameScreen;
 
 namespace zzre.game.systems.ui;
 
-public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, messages.ui.OpenBookMenu>
+public partial class ScrMapMenu : BaseScreen<components.ui.ScrMapMenu, messages.ui.OpenMapMenu>
 {
     private readonly MappedDB db;
 
-    public ScrBookMenu(ITagContainer diContainer) : base(diContainer, BlockFlags.All)
+    public ScrMapMenu(ITagContainer diContainer) : base(diContainer, BlockFlags.All)
     {
         db = diContainer.GetTag<MappedDB>();
         OnElementDown += HandleElementDown;
     }
 
-    protected override void HandleOpen(in messages.ui.OpenBookMenu message)
+    protected override void HandleOpen(in messages.ui.OpenMapMenu message)
     {
         var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
-        if (!inventory.Contains(StdItemId.FairyBook))
+        if (!inventory.Contains(StdItemId.MapFairyGarden))
             return;
 
         var entity = World.CreateEntity();
-        entity.Set<components.ui.ScrBookMenu>();
-        ref var bookMenu = ref entity.Get<components.ui.ScrBookMenu>();
-        bookMenu.Inventory = inventory;
+        entity.Set<components.ui.ScrMapMenu>();
+        ref var mapMenu = ref entity.Get<components.ui.ScrMapMenu>();
+        mapMenu.Inventory = inventory;
 
         preload.CreateImage(entity)
             .With(-new Vector2(320, 240))
-            .WithBitmap("col000")
+            .WithBitmap("map001")
             .WithRenderOrder(1)
             .Build();
 
@@ -41,53 +41,53 @@ public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, message
             .WithText("{205} - ")
             .Build();
 
-        CreateTopButtons(preload, entity, inventory, IDOpenFairybook);
+        CreateTopButtons(preload, entity, inventory, IDOpenMap);
     }
 
-    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.ui.ScrBookMenu bookMenu)
+    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.ui.ScrMapMenu mapMenu)
     {
-        base.Update(timeElapsed, entity, ref bookMenu);
+        base.Update(timeElapsed, entity, ref mapMenu);
     }
 
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId id)
     {
-        var bookMenuEntity = Set.GetEntities()[0];
+        var mapMenuEntity = Set.GetEntities()[0];
         if (id == IDOpenDeck)
         {
-            bookMenuEntity.Dispose();
+            mapMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenDeck>();
         }
         else if (id == IDOpenRunes)
         {
-            bookMenuEntity.Dispose();
+            mapMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
         }
-        else if (id == IDOpenMap)
+        else if (id == IDOpenFairybook)
         {
-            bookMenuEntity.Dispose();
-            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+            mapMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
         else if (id == IDClose)
-            bookMenuEntity.Dispose();
+            mapMenuEntity.Dispose();
     }
 
     protected override void HandleKeyDown(Key key)
     {
-        var bookMenuEntity = Set.GetEntities()[0];
+        var mapMenuEntity = Set.GetEntities()[0];
         base.HandleKeyDown(key);
         if (key == Key.F2) {
-            bookMenuEntity.Dispose();
+            mapMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenRuneMenu>();
         }
-        if (key == Key.F4) {
-            bookMenuEntity.Dispose();
-            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        if (key == Key.F3) {
+            mapMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
         if (key == Key.F5) {
-            bookMenuEntity.Dispose();
+            mapMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenDeck>();
         }
-        if (key == Key.Enter || key == Key.Escape || key == Key.F3)
+        if (key == Key.Enter || key == Key.Escape || key == Key.F4)
             Set.DisposeAll();
     }
 }

--- a/zzre/game/systems/ui/ScrRuneMenu.cs
+++ b/zzre/game/systems/ui/ScrRuneMenu.cs
@@ -147,6 +147,11 @@ public partial class ScrRuneMenu : BaseScreen<components.ui.ScrRuneMenu, message
             runeMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenDeck>();
         }
+        else if (id == IDOpenFairybook)
+        {
+            runeMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
+        }
         else if (id == IDClose)
             runeMenuEntity.Dispose();
     }
@@ -155,10 +160,10 @@ public partial class ScrRuneMenu : BaseScreen<components.ui.ScrRuneMenu, message
     {
         var runeMenuEntity = Set.GetEntities()[0];
         base.HandleKeyDown(key);
-        // if (key == Key.F3) {
-        //     runeMenuEntity.Dispose();
-        //     zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
-        // }
+        if (key == Key.F3) {
+            runeMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
+        }
         // if (key == Key.F4) {
         //     runeMenuEntity.Dispose();
         //     zanzarah.UI.Publish<messages.ui.OpenMapMenu>();

--- a/zzre/game/systems/ui/ScrRuneMenu.cs
+++ b/zzre/game/systems/ui/ScrRuneMenu.cs
@@ -152,6 +152,11 @@ public partial class ScrRuneMenu : BaseScreen<components.ui.ScrRuneMenu, message
             runeMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
+        else if (id == IDOpenMap)
+        {
+            runeMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        }
         else if (id == IDClose)
             runeMenuEntity.Dispose();
     }
@@ -164,10 +169,10 @@ public partial class ScrRuneMenu : BaseScreen<components.ui.ScrRuneMenu, message
             runeMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenBookMenu>();
         }
-        // if (key == Key.F4) {
-        //     runeMenuEntity.Dispose();
-        //     zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
-        // }
+        if (key == Key.F4) {
+            runeMenuEntity.Dispose();
+            zanzarah.UI.Publish<messages.ui.OpenMapMenu>();
+        }
         if (key == Key.F5) {
             runeMenuEntity.Dispose();
             zanzarah.UI.Publish<messages.ui.OpenDeck>();

--- a/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
+++ b/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
@@ -62,7 +62,7 @@ partial class ECSExplorer
         AddEntityNamerByComponent<ScrGotCard>(High, nameof(ScrGotCard));
         AddEntityNamerByComponent<ScrRuneMenu>(High, nameof(ScrRuneMenu));
         AddEntityNamerByComponent<ScrBookMenu>(High, nameof(ScrBookMenu));
-        AddEntityNamerByComponent<ScrMapMenu>(High, nameof(ScrBookMenu));
+        AddEntityNamerByComponent<ScrMapMenu>(High, nameof(ScrMapMenu));
         AddEntityNamerByComponent<ScrNotification>(High, nameof(ScrNotification));
 
         static string Sanitize(string t) => t[0..Math.Min(16, t.Length)].Replace("\n", "\\n").Replace("\t", "\\t");

--- a/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
+++ b/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
@@ -62,6 +62,7 @@ partial class ECSExplorer
         AddEntityNamerByComponent<ScrGotCard>(High, nameof(ScrGotCard));
         AddEntityNamerByComponent<ScrRuneMenu>(High, nameof(ScrRuneMenu));
         AddEntityNamerByComponent<ScrBookMenu>(High, nameof(ScrBookMenu));
+        AddEntityNamerByComponent<ScrMapMenu>(High, nameof(ScrBookMenu));
         AddEntityNamerByComponent<ScrNotification>(High, nameof(ScrNotification));
 
         static string Sanitize(string t) => t[0..Math.Min(16, t.Length)].Replace("\n", "\\n").Replace("\t", "\\t");

--- a/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
+++ b/zzre/tools/ECSExplorer/ECSExplorer.Standard.cs
@@ -61,6 +61,7 @@ partial class ECSExplorer
         AddEntityNamerByComponent<ScrDeck>(High, nameof(ScrDeck));
         AddEntityNamerByComponent<ScrGotCard>(High, nameof(ScrGotCard));
         AddEntityNamerByComponent<ScrRuneMenu>(High, nameof(ScrRuneMenu));
+        AddEntityNamerByComponent<ScrBookMenu>(High, nameof(ScrBookMenu));
         AddEntityNamerByComponent<ScrNotification>(High, nameof(ScrNotification));
 
         static string Sanitize(string t) => t[0..Math.Min(16, t.Length)].Replace("\n", "\\n").Replace("\t", "\\t");


### PR DESCRIPTION
Added the boilerplate for the fairy book menu, without any logic specific to that menu.

Tested to have all the buttons connect up properly.

Tested that the menu is only available while holding the Fairy Book.

![book-menu](https://github.com/Helco/zzio/assets/28656100/20885d6e-7708-4e46-b748-541dd9aafccf)
