### PR TITLE
zzre: fix type of SpellRow.Info

### DIFF
--- a/zzio/db/SpellRow.cs
+++ b/zzio/db/SpellRow.cs
@@ -14,7 +14,7 @@ public class SpellRow : MappedRow
     public byte PriceB => row.cells[4].Byte;
     public byte PriceC => row.cells[5].Byte;
 
-    public string Info => row.cells[6].String;
+    public string Info => foreignText(6);
 
     public int Mana => row.cells[7].Integer;
 


### PR DESCRIPTION
Fixes a minor bug I discovered while making a Spell Book menu for fun