### PR TITLE
zzre: Dialog: Gambling

### DIFF
--- a/zzio/db/SpellRow.cs
+++ b/zzio/db/SpellRow.cs
@@ -10,9 +10,9 @@ public class SpellRow : MappedRow
 
     public CardId CardId => new(row.cells[2].Integer);
 
-    public byte PriceA => row.cells[3].Byte;
-    public byte PriceB => row.cells[4].Byte;
-    public byte PriceC => row.cells[5].Byte;
+    public ZZClass PriceA => (ZZClass)row.cells[3].Byte;
+    public ZZClass PriceB => (ZZClass)row.cells[4].Byte;
+    public ZZClass PriceC => (ZZClass)row.cells[5].Byte;
 
     public string Info => foreignText(6);
 

--- a/zzre/game/Game.cs
+++ b/zzre/game/Game.cs
@@ -120,6 +120,7 @@ public class Game : BaseDisposable, ITagContainer
             new systems.DialogLookAt(this),
             new systems.DialogChoice(this),
             new systems.DialogTrading(this),
+            new systems.DialogGambling(this),
 
             new systems.NonFairyAnimation(this),
             

--- a/zzre/game/StdSpellId.cs
+++ b/zzre/game/StdSpellId.cs
@@ -26,8 +26,8 @@ public static class StdSpells
     {
         var price =
             (spell.PriceA != zzio.ZZClass.None ? 1 : 0) +
-            (spell.PriceB != zzio.ZZClass.None && spell.PriceB != zzio.ZZClass.Nature ? 1 : 0) +
-            (spell.PriceC != zzio.ZZClass.None && spell.PriceC != zzio.ZZClass.Nature ? 1 : 0);
+            (spell.PriceB != zzio.ZZClass.None ? 1 : 0) +
+            (spell.PriceC != zzio.ZZClass.None ? 1 : 0);
         var maxPrice = GetMaxPriceFor(level);
         var maxRelevantPrice = spell.Type == 0 ? maxPrice.attack : maxPrice.support;
         return spell.PriceA == zzClass && price <= maxRelevantPrice;

--- a/zzre/game/StdSpellId.cs
+++ b/zzre/game/StdSpellId.cs
@@ -25,12 +25,12 @@ public static class StdSpells
     private static bool IsSpellCompatible(SpellRow spell, zzio.ZZClass zzClass, uint level)
     {
         var price =
-            (spell.PriceA > 0 ? 1 : 0) +
-            (spell.PriceB > 1 ? 1 : 0) +
-            (spell.PriceC > 1 ? 1 : 0);
+            (spell.PriceA != zzio.ZZClass.None ? 1 : 0) +
+            (spell.PriceB != zzio.ZZClass.None && spell.PriceB != zzio.ZZClass.Nature ? 1 : 0) +
+            (spell.PriceC != zzio.ZZClass.None && spell.PriceC != zzio.ZZClass.Nature ? 1 : 0);
         var maxPrice = GetMaxPriceFor(level);
         var maxRelevantPrice = spell.Type == 0 ? maxPrice.attack : maxPrice.support;
-        return spell.PriceA == (byte)zzClass && price <= maxRelevantPrice;
+        return spell.PriceA == zzClass && price <= maxRelevantPrice;
     }
 
     public static StdSpellId GetStarterSpellFor(zzio.ZZClass zzClass) => zzClass switch

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -13,5 +13,5 @@ public struct DialogGambling
     public List<int?> Cards;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
-    public float RowAnimationTimeLeft;
+    public float? RowAnimationTimeLeft;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -8,13 +8,16 @@ namespace zzre.game.components;
 public struct DialogGambling
 {
     public DefaultEcs.Entity DialogEntity;
+
     public ItemRow Currency;
-    public SpellRow? Purchase;
     public List<int?> Cards;
     public List<SpellRow?> SelectedCards;
+    public SpellRow? Purchase;
+
     public Rect bgRect;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity CurrencyLabel;
     public DefaultEcs.Entity Profile;
+
     public float? RowAnimationTimeLeft;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using zzio;
+using zzio.db;
+
+namespace zzre.game.components;
+
+public struct DialogGambling
+{
+    public DefaultEcs.Entity DialogEntity;
+    public ItemRow? Purchase;
+    public List<(int count, int id)> Cards;
+    public Dictionary<components.ui.ElementId, ItemRow> CardPurchaseButtons;
+    public DefaultEcs.Entity Profile;
+}

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -11,6 +11,6 @@ public struct DialogGambling
     public ItemRow Currency;
     public ItemRow? Purchase;
     public List<(int count, int id)> Cards;
-    public Dictionary<components.ui.ElementId, ItemRow> CardPurchaseButtons;
+    public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -10,7 +10,7 @@ public struct DialogGambling
     public DefaultEcs.Entity DialogEntity;
     public ItemRow Currency;
     public SpellRow? Purchase;
-    public List<int> Cards;
+    public List<int?> Cards;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -14,6 +14,7 @@ public struct DialogGambling
     public List<SpellRow?> SelectedCards;
     public Rect bgRect;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
+    public DefaultEcs.Entity CurrencyLabel;
     public DefaultEcs.Entity Profile;
     public float? RowAnimationTimeLeft;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -14,7 +14,7 @@ public struct DialogGambling
     public List<SpellRow?> SelectedCards;
     public SpellRow? Purchase;
 
-    public Rect bgRect;
+    public Rect BgRect;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity CurrencyLabel;
     public DefaultEcs.Entity Profile;

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -11,6 +11,8 @@ public struct DialogGambling
     public ItemRow Currency;
     public SpellRow? Purchase;
     public List<int?> Cards;
+    public List<SpellRow?> SelectedCards;
+    public Rect bgRect;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
     public float? RowAnimationTimeLeft;

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -9,7 +9,7 @@ public struct DialogGambling
 {
     public DefaultEcs.Entity DialogEntity;
     public ItemRow Currency;
-    public ItemRow? Purchase;
+    public SpellRow? Purchase;
     public List<int> Cards;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -13,4 +13,5 @@ public struct DialogGambling
     public List<int?> Cards;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
+    public float RowAnimationTimeLeft;
 }

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -8,6 +8,7 @@ namespace zzre.game.components;
 public struct DialogGambling
 {
     public DefaultEcs.Entity DialogEntity;
+    public ItemRow Currency;
     public ItemRow? Purchase;
     public List<(int count, int id)> Cards;
     public Dictionary<components.ui.ElementId, ItemRow> CardPurchaseButtons;

--- a/zzre/game/components/dialog/DialogGambling.cs
+++ b/zzre/game/components/dialog/DialogGambling.cs
@@ -10,7 +10,7 @@ public struct DialogGambling
     public DefaultEcs.Entity DialogEntity;
     public ItemRow Currency;
     public ItemRow? Purchase;
-    public List<(int count, int id)> Cards;
+    public List<int> Cards;
     public Dictionary<components.ui.ElementId, SpellRow> CardPurchaseButtons;
     public DefaultEcs.Entity Profile;
 }

--- a/zzre/game/components/dialog/DialogState.cs
+++ b/zzre/game/components/dialog/DialogState.cs
@@ -8,6 +8,7 @@ public enum DialogState
     Talk,
     Choice,
     Trading,
+    Gambling,
     PreFightWild,
     PreFightNpc,
     NpcWalking,

--- a/zzre/game/messages/dialog/DialogGambling.cs
+++ b/zzre/game/messages/dialog/DialogGambling.cs
@@ -5,6 +5,6 @@ namespace zzre.game.messages;
 
 public record struct DialogGambling(
     DefaultEcs.Entity DialogEntity,
-    List<int> Cards
+    List<int?> Cards
 );
 

--- a/zzre/game/messages/dialog/DialogGambling.cs
+++ b/zzre/game/messages/dialog/DialogGambling.cs
@@ -5,6 +5,6 @@ namespace zzre.game.messages;
 
 public record struct DialogGambling(
     DefaultEcs.Entity DialogEntity,
-    List<(int count, int id)> Cards
+    List<int> Cards
 );
 

--- a/zzre/game/messages/dialog/DialogGambling.cs
+++ b/zzre/game/messages/dialog/DialogGambling.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using zzio;
+
+namespace zzre.game.messages;
+
+public record struct DialogGambling(
+    DefaultEcs.Entity DialogEntity,
+    List<(int count, int id)> Cards
+);
+

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -70,9 +70,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         gambling.Profile = CreatePrimary(uiEntity, ref gambling, animate: true);
     }
-    private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, ref components.DialogGambling gambling, bool animate = false)
+    private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, ref components.DialogGambling gambling, bool animate = false, bool allowTradeButtons = true)
     {
-        Console.WriteLine("Creating Primary Profile");
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
 
@@ -88,7 +87,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             for (int i = 0; i < rows; i++) {
                 gambling.SelectedCards.Add(PullRandomCard(ref gambling));
                 AddTrade(entity, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
-                AddTradeButton(entity, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
+                if (allowTradeButtons)
+                    AddTradeButton(entity, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
             }
             preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, gambling.bgRect);
             preload.CreateSingleButton(entity, new UID(0x91A7E821), IDRepeat, gambling.bgRect, offset: 1);
@@ -236,7 +236,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         else if (clickedId == IDYes) {
             zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Add(gambling.Purchase!.CardId);
             gambling.Profile.Dispose();
-            gambling.Profile = CreatePrimary(uiEntity, ref gambling);
+            gambling.Profile = CreatePrimary(uiEntity, ref gambling, allowTradeButtons: false);
         }
         else if (clickedId == IDNo) {
             gambling.Profile.Dispose();

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -14,9 +14,13 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly components.ui.ElementId IDYes = new(1002);
     private static readonly components.ui.ElementId IDNo = new(1003);
 
-    private static readonly UID UIDPurchaseItem = new(0x7B973CA1);
-    private static readonly UID UIDItemProfile = new(0x2C2084B1);
     private static readonly UID UIDYouHave = new(0x070EE421);
+
+    private static readonly UID UIDSpellProfile = new(0xBFC6DD81);
+    private static readonly UID UIDTakeIt = new(0x84D35581);
+    private static readonly UID UIDANewSpell = new(0xC38FEBB1);
+    private static readonly UID UIDOffensiveSpell = new(0xD4B02981);
+    private static readonly UID UIDPassiveSpell = new(0x515E2981);
 
     private static readonly UID[] UIDClassNames = new UID[]
     {
@@ -107,50 +111,64 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         preload.CreateLabel(entity)
             .With(bgRect.Min + new Vector2(30, 22))
             .With(preload.Fnt001)
-            .WithText(db.GetText(UIDItemProfile).Text)
+            .WithText(db.GetText(UIDSpellProfile).Text)
             .Build();
 
         preload.CreateImage(entity)
-            .With(bgRect.Center + new Vector2(-20, -100))
+            .With(bgRect.Min + new Vector2(50+40, 50+26))
             .With(preload.Spl000, card.CardId.EntityId)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(bgRect.Center + new Vector2(-72, -40))
-            .With(preload.Fnt001)
+            .With(bgRect.Min + new Vector2(70+40+30, 50+33))
+            .With(preload.Fnt003)
             .WithText(card.Name)
             .Build();
 
-        preload.CreateLabel(entity)
-            .With(bgRect.Min + new Vector2(50, 250))
-            .With(preload.Fnt000)
-            .WithText(card.Info)
-            .WithLineHeight(14)
-            .WithLineWrap(bgRect.Size.X - 100)
-            .WithAnimation()
-            .Build();
+        var texts = new (int row, int col, string text)[] {
+            (0, 0, db.GetText(UIDANewSpell).Text.ToUpper()),
+            (1, 0, "Offensive Spell - Nature"),
+            (2, 0, "Mana"),
+            (2, 1, $"{{1004}}{card.MaxMana}/{card.MaxMana}"),
+            (3, 0, "Level"),
+            (3, 1, GetSpellPrices(card)),
+            (4, 0, "Damage"),
+            (4, 1, ConvertTextIcons(card.Damage)),
+            (5, 0, "Fire Rate"),
+            (5, 1, ConvertTextIcons(card.Loadup))
+        };
+        for (int i = 0; i < texts.Length; i++)
+            preload.CreateLabel(entity)
+                .With(bgRect.Min + new Vector2(50+40 + texts[i].col * 90, 100+36 + texts[i].row * 28))
+                .With(preload.Fnt002)
+                .WithText(texts[i].text)
+                .Build();
 
         preload.CreateLabel(entity)
-            .With(new Vector2(bgRect.Center.X - 76, bgRect.Max.Y - 46))
+            .With(new Vector2(bgRect.Center.X - 76-59, bgRect.Max.Y - 46))
             .With(preload.Fnt002)
-            .WithText(db.GetText(UIDPurchaseItem).Text)
+            .WithText(db.GetText(UIDTakeIt).Text)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDYes)
-            .With(new Vector2(bgRect.Center.X + 20, bgRect.Max.Y - 65))
+            .With(new Vector2(bgRect.Center.X + 20-70, bgRect.Max.Y - 65+5))
             .With(new components.ui.ButtonTiles(5, 6))
             .With(preload.Btn000)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDNo)
-            .With(new Vector2(bgRect.Center.X + 56, bgRect.Max.Y - 65))
+            .With(new Vector2(bgRect.Center.X + 56-56, bgRect.Max.Y - 65+5))
             .With(new components.ui.ButtonTiles(7, 8))
             .With(preload.Btn000)
             .Build();
 
         return entity;
+    }
+
+    private string ConvertTextIcons(int value) {
+        return string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value));
     }
 
     private void CreateTopbar(DefaultEcs.Entity parent, ItemRow currency)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -22,6 +22,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly UID UIDPassiveSpell = new(0x515E2981);
 
     private readonly int currencyI = 23;
+    private readonly int cloverleafI = 64;
     private readonly int rows = 5;
     private readonly int pricePerRow = 2;
     private readonly float rowAnimationDelay = 0.5f;
@@ -60,7 +61,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         uiEntity.Set(new components.DialogGambling{
             DialogEntity = message.DialogEntity,
             Currency = db.Items.ElementAt(currencyI),
-            Cards = message.Cards,
+            Cards = CloverLeafFilter(message.Cards),
             SelectedCards = new(),
             CardPurchaseButtons = new()
         });
@@ -268,6 +269,18 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var className = preload.GetClassText(card.PriceA);
         var prices = preload.GetSpellPrices(card);
         return $"{name}\n{type} - {className} - {prices}";
+    }
+
+    private List<int?> CloverLeafFilter(List<int?> cards) {
+        if (!zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Contains(db.Items.ElementAt(cloverleafI).CardId))
+            return cards;
+
+        List<int?> filteredCards = new();
+        Random rnd = new();
+        foreach (var card in cards)
+            if (card != null || rnd.NextDouble() >= 0.8)
+                filteredCards.Add(card);
+        return filteredCards;
     }
 
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -25,9 +25,9 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly UID UIDSpellProfile = new(0xBFC6DD81);
     private static readonly UID UIDTakeIt = new(0x84D35581);
     private static readonly UID UIDNewSpell = new(0xC38FEBB1);
-    private static readonly UID UIDOldSpell = new(0x92A1EBB1);
-    private static readonly UID UIDOldSpell1 = new(0xE9C9EFB1);
-    private static readonly UID UIDOldSpell2 = new(0x8B19EFB1);
+    private static readonly UID UIDOldSpell = new(0x92A1EBB1); // You already have this spell!
+    private static readonly UID UIDOldSpell1 = new(0xE9C9EFB1); // Number:
+    private static readonly UID UIDOldSpell2 = new(0x8B19EFB1); // , in use:
 
     private static readonly UID UIDMana = new(0x238A3981);
     private static readonly UID UIDLevel = new(0xCDF3D81);
@@ -73,7 +73,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         uiEntity.Set(new components.DialogGambling{
             DialogEntity = message.DialogEntity,
-            Currency = db.Items.ElementAt(currencyI),
             Cards = CloverleafFilter(message.Cards),
             SelectedCards = new(),
             CardPurchaseButtons = new()

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -61,7 +61,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         uiEntity.Set(new components.DialogGambling{
             DialogEntity = message.DialogEntity,
             Currency = db.Items.ElementAt(currencyI),
-            Cards = CloverLeafFilter(message.Cards),
+            Cards = CloverleafFilter(message.Cards),
             SelectedCards = new(),
             CardPurchaseButtons = new()
         });
@@ -271,9 +271,11 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         return $"{name}\n{type} - {className} - {prices}";
     }
 
-    private List<int?> CloverLeafFilter(List<int?> cards) {
-        if (!zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Contains(db.Items.ElementAt(cloverleafI).CardId))
-            return cards;
+    private bool HasCloverleaf() =>
+        zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Contains(db.Items.ElementAt(cloverleafI).CardId);
+
+    private List<int?> CloverleafFilter(List<int?> cards) {
+        if (!HasCloverleaf()) return cards;
 
         List<int?> filteredCards = new();
         Random rnd = new();

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -98,11 +98,24 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         gambling.CurrencyLabel = preload.CreateCurrencyLabel(entity, gambling.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         if (gambling.SelectedCards.Count == rows) {
             RebuildPrimary(entity, ref gambling, allowPurchaseButtons);
+        } else if (!CanAfford(ref gambling)) {
+            MessageCannotAfford(entity, ref gambling);
         } else {
             StartAnimation(ref gambling);
         }
 
         return entity;
+    }
+
+    private void MessageCannotAfford(DefaultEcs.Entity parent, ref components.DialogGambling gambling)
+    {
+        preload.CreateLabel(parent)
+            .With(gambling.bgRect.Center + new Vector2(0, -3))
+            .With(preload.Fnt000)
+            .WithText("You do not have enough money!")
+            .With(components.ui.FullAlignment.Center)
+            .Build();
+        AddBottomButtons(parent, ref gambling);
     }
 
     private void RebuildPrimary(DefaultEcs.Entity parent, ref components.DialogGambling gambling, bool allowPurchaseButtons)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -129,13 +129,13 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             (0, 0, db.GetText(UIDANewSpell).Text.ToUpper()),
             (1, 0, "Offensive Spell - Nature"),
             (2, 0, "Mana"),
-            (2, 1, $"{{1004}}{card.MaxMana}/{card.MaxMana}"),
+            (2, 1, card.Mana == 5 ? "{{1004}}-/-" : $"{{1004}}{card.MaxMana}/{card.MaxMana}"),
             (3, 0, "Level"),
-            (3, 1, GetSpellPrices(card)),
+            (3, 1, preload.GetSpellPrices(card)),
             (4, 0, "Damage"),
-            (4, 1, ConvertTextIcons(card.Damage)),
+            (4, 1, preload.GetLightsIndicator(card.Damage)),
             (5, 0, "Fire Rate"),
-            (5, 1, ConvertTextIcons(card.Loadup))
+            (5, 1, preload.GetLightsIndicator(card.Loadup))
         };
         for (int i = 0; i < texts.Length; i++)
             preload.CreateLabel(entity)
@@ -165,10 +165,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         return entity;
-    }
-
-    private string ConvertTextIcons(int value) {
-        return string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value));
     }
 
     private void CreateTopbar(DefaultEcs.Entity parent, ItemRow currency)
@@ -224,13 +220,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var name = card.Name;
         var type = card.Type == 0 ? "Active Spell" : "Passive Spell";
         var className = db.GetText(UIDClassNames[card.PriceA-1]).Text;
-        var prices = GetSpellPrices(card);
+        var prices = preload.GetSpellPrices(card);
         return $"{name}\n{type} - {className} - {prices}";
-    }
-
-    private string GetSpellPrices(SpellRow card) {
-        var sheet = card.Type == 0 ? 5 : 4;
-        return $"{{{sheet}{card.PriceA}}}{{{sheet}{card.PriceB}}}{{{sheet}{card.PriceC}}}";
     }
 
     private const float ButtonOffsetY = -50f;

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -64,7 +64,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
     protected override void HandleOpen(in messages.DialogGambling message)
     {
-        message.DialogEntity.Set(components.DialogState.Talk);
+        message.DialogEntity.Set(components.DialogState.Gambling);
         World.Publish(new messages.DialogResetUI(message.DialogEntity));
 
         var uiEntity = World.CreateEntity();

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -112,7 +112,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             (0, 0, db.GetText(UIDANewSpell).Text.ToUpper(new CultureInfo("en-US", false))),
             (1, 0, "Offensive Spell - Nature"),
             (2, 0, "Mana"),
-            (2, 1, card.Mana == 5 ? "{1004}-/-" : $"{1004}{card.MaxMana}/{card.MaxMana}"),
+            (2, 1, "{104}" + (card.Mana == 5 ? "-/-" : $"{card.MaxMana}/{card.MaxMana}")),
             (3, 0, "Level"),
             (3, 1, preload.GetSpellPrices(card)),
             (4, 0, "Damage"),

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -211,11 +211,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     }
 
     private string GetSpellPrices(SpellRow card) {
-        var fontAlt = card.Type == 0 ? 5 : 4;
-        var priceA = fontAlt * 1000 + card.PriceA;
-        var priceB = fontAlt * 1000 + card.PriceB;
-        var priceC = fontAlt * 1000 + card.PriceC;
-        return $"{{{priceA}}}{{{priceB}}}{{{priceC}}}";
+        var sheet = card.Type == 0 ? 5 : 4;
+        return $"{{{fontAlt}{card.PriceA}}}{{{fontAlt}{card.PriceB}}}{{{fontAlt}{card.PriceC}}}";
     }
 
 

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -112,7 +112,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             (0, 0, db.GetText(UIDANewSpell).Text.ToUpper(new CultureInfo("en-US", false))),
             (1, 0, "Offensive Spell - Nature"),
             (2, 0, "Mana"),
-            (2, 1, card.Mana == 5 ? "{{1004}}-/-" : $"{{1004}}{card.MaxMana}/{card.MaxMana}"),
+            (2, 1, card.Mana == 5 ? "{1004}-/-" : $"{1004}{card.MaxMana}/{card.MaxMana}"),
             (3, 0, "Level"),
             (3, 1, preload.GetSpellPrices(card)),
             (4, 0, "Damage"),

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using System.Collections.Generic;
+using zzio;
+using zzio.db;
+
+namespace zzre.game.systems;
+
+public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, messages.DialogGambling>
+{
+    private readonly MappedDB db;
+    private readonly IDisposable resetUISubscription;
+
+    public DialogGambling(ITagContainer diContainer) : base(diContainer, BlockFlags.None)
+    {
+        db = diContainer.GetTag<MappedDB>();
+
+        resetUISubscription = World.Subscribe<messages.DialogResetUI>(HandleResetUI);
+        OnElementDown += HandleElementDown;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        resetUISubscription.Dispose();
+    }
+
+    private void HandleResetUI(in messages.DialogResetUI message)
+    {
+        foreach (var entity in Set.GetEntities())
+            entity.Dispose();
+    }
+
+    protected override void HandleOpen(in messages.DialogGambling message)
+    {
+        message.DialogEntity.Set(components.DialogState.Trading);
+
+        World.Publish(new messages.DialogResetUI(message.DialogEntity));
+        var uiEntity = World.CreateEntity();
+        uiEntity.Set(new components.Parent(message.DialogEntity));
+
+        Console.WriteLine(message.Cards);
+
+        uiEntity.Set(new components.DialogGambling{
+            DialogEntity = message.DialogEntity,
+            Cards = message.Cards,
+            CardPurchaseButtons = new()
+        });
+        // ref var trading = ref uiEntity.Get<components.DialogGambling>();
+
+        // trading.Profile = CreatePrimary(uiEntity, trading);
+    }
+/*
+    private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, components.DialogGambling trading)
+    {
+        var entity = World.CreateEntity();
+        entity.Set(new components.Parent(parent));
+
+        preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
+        CreateTopbar(entity, trading.Currency);
+        for (int i = 0; i < trading.CardTrades.Count; i++)
+            AddTrade(entity, trading, i, bgRect);
+        CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
+
+        return entity;
+    }
+
+    private DefaultEcs.Entity CreateItemProfile(DefaultEcs.Entity parent, components.DialogGambling trading, ItemRow card)
+    {
+        var entity = World.CreateEntity();
+        entity.Set(new components.Parent(parent));
+
+        preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
+
+        preload.CreateLabel(entity)
+            .With(bgRect.Min + new Vector2(30, 22))
+            .With(preload.Fnt001)
+            .WithText(db.GetText(UIDItemProfile).Text)
+            .Build();
+
+        preload.CreateImage(entity)
+            .With(bgRect.Center + new Vector2(-20, -100))
+            .With(preload.Itm000, card.CardId.EntityId)
+            .Build();
+
+        preload.CreateLabel(entity)
+            .With(bgRect.Center + new Vector2(-72, -40))
+            .With(preload.Fnt001)
+            .WithText(card.Name)
+            .Build();
+
+        preload.CreateLabel(entity)
+            .With(bgRect.Min + new Vector2(50, 250))
+            .With(preload.Fnt000)
+            .WithText(card.Info)
+            .WithLineHeight(14)
+            .WithLineWrap(bgRect.Size.X - 100)
+            .WithAnimation()
+            .Build();
+
+        preload.CreateLabel(entity)
+            .With(new Vector2(bgRect.Center.X - 76, bgRect.Max.Y - 46))
+            .With(preload.Fnt002)
+            .WithText(db.GetText(UIDPurchaseItem).Text)
+            .Build();
+
+        preload.CreateButton(entity)
+            .With(IDYes)
+            .With(new Vector2(bgRect.Center.X + 20, bgRect.Max.Y - 65))
+            .With(new components.ui.ButtonTiles(5, 6))
+            .With(preload.Btn000)
+            .Build();
+
+        preload.CreateButton(entity)
+            .With(IDNo)
+            .With(new Vector2(bgRect.Center.X + 56, bgRect.Max.Y - 65))
+            .With(new components.ui.ButtonTiles(7, 8))
+            .With(preload.Btn000)
+            .Build();
+
+        return entity;
+    }
+
+    private void CreateTopbar(DefaultEcs.Entity parent, ItemRow currency)
+    {
+        var amountOwned = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().CountCards(currency.CardId);
+
+        preload.CreateLabel(parent)
+            .With(new Vector2(-60, -170))
+            .With(preload.Fnt000)
+            .WithText($"{db.GetText(UIDYouHave).Text} {{{3000 + currency.CardId.EntityId}}}x{amountOwned}")
+            .Build();
+    }
+
+    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling trading, int index, Rect bgRect)
+    {
+        var price = trading.CardTrades[index].price;
+        var card = db.GetItem(trading.CardTrades[index].uid);
+
+        var purchase = new components.ui.ElementId(index);
+        var offset = bgRect.Center + new Vector2(-205, -120 + 55 * index);
+
+        preload.CreateImage(entity)
+            .With(offset)
+            .With(preload.Itm000, card.CardId.EntityId)
+            .Build();
+
+        preload.CreateLabel(entity)
+            .With(offset + new Vector2(50, 16))
+            .WithText(card.Name)
+            .With(preload.Fnt002)
+            .Build();
+
+        preload.CreateLabel(entity)
+            .With(offset + new Vector2(325, 12))
+            .WithText($"{{0*x}}{price}")
+            .With(preload.Fnt000)
+            .Build();
+
+        var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
+        if (inventory.CountCards(trading.Currency.CardId) >= price) {
+            preload.CreateButton(entity)
+                .With(purchase)
+                .With(offset + new Vector2(365, 0))
+                .With(new components.ui.ButtonTiles(20, 21))
+                .With(preload.Btn001)
+                .Build();
+        } else {
+            preload.CreateImage(entity)
+                .With(offset + new Vector2(365, 0))
+                .With(preload.Btn001, 22)
+                .Build();
+        }
+
+        trading.CardPurchaseButtons[purchase] = card;
+    }
+
+    private const float ButtonOffsetY = -50f;
+    private void CreateSingleButton(DefaultEcs.Entity entity, UID textUID, components.ui.ElementId elementId, Rect bgRect)
+    {
+        preload.CreateButton(entity)
+            .With(elementId)
+            .With(new Vector2(bgRect.Center.X, bgRect.Max.Y + ButtonOffsetY))
+            .With(new components.ui.ButtonTiles(0, 1))
+            .With(components.ui.FullAlignment.TopCenter)
+            .With(preload.Btn000)
+            .WithLabel()
+            .With(preload.Fnt000)
+            .WithText(textUID)
+            .Build();
+
+        // TODO: Set cursor position in dialog trading
+    }*/
+    private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)
+    {
+        // var uiEntity = Set.GetEntities()[0];
+        // ref var trading = ref uiEntity.Get<components.DialogGambling>();
+        //
+        // if (trading.CardPurchaseButtons.TryGetValue(clickedId, out var card)) {
+        //     trading.Profile.Dispose();
+        //     trading.Purchase = card;
+        //     trading.Profile = CreateItemProfile(uiEntity, trading, card);
+        // }
+        // else if (clickedId == IDYes) {
+        //     var purchase = trading.Purchase!;
+        //     var price = trading.CardTrades.First(trade => trade.uid == purchase.Uid).price;
+        //
+        //     var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
+        //     inventory.Add(purchase.CardId);
+        //     inventory.RemoveCards(trading.Currency.CardId, (uint)price);
+        //
+        //     trading.Profile.Dispose();
+        //     trading.Profile = CreatePrimary(uiEntity, trading);
+        // }
+        // else if (clickedId == IDNo) {
+        //     trading.Profile.Dispose();
+        //     trading.Purchase = null;;
+        //     trading.Profile = CreatePrimary(uiEntity, trading);
+        // }
+        // else if (clickedId == IDExit) {
+        //     trading.DialogEntity.Set(components.DialogState.NextScriptOp);
+        //     uiEntity.Dispose();
+        // }
+    }
+
+    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.DialogGambling component)
+    {
+    }
+}

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -79,7 +79,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         return entity;
     }
 
-    private DefaultEcs.Entity CreateItemProfile(DefaultEcs.Entity parent, components.DialogGambling gambling, ItemRow card)
+    private DefaultEcs.Entity CreateItemProfile(DefaultEcs.Entity parent, components.DialogGambling gambling, SpellRow card)
     {
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
@@ -94,7 +94,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         preload.CreateImage(entity)
             .With(bgRect.Center + new Vector2(-20, -100))
-            .With(preload.Itm000, card.CardId.EntityId)
+            .With(preload.Spl000, card.CardId.EntityId)
             .Build();
 
         preload.CreateLabel(entity)
@@ -193,34 +193,32 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     }
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)
     {
-        // var uiEntity = Set.GetEntities()[0];
-        // ref var gambling = ref uiEntity.Get<components.DialogGambling>();
-        //
-        // if (gambling.CardPurchaseButtons.TryGetValue(clickedId, out var card)) {
-        //     gambling.Profile.Dispose();
-        //     gambling.Purchase = card;
-        //     gambling.Profile = CreateItemProfile(uiEntity, gambling, card);
-        // }
-        // else if (clickedId == IDYes) {
-        //     var purchase = gambling.Purchase!;
-        //     var price = gambling.Cards.First(trade => trade.uid == purchase.Uid).price;
-        //
-        //     var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
-        //     inventory.Add(purchase.CardId);
-        //     inventory.RemoveCards(gambling.Currency.CardId, (uint)price);
-        //
-        //     gambling.Profile.Dispose();
-        //     gambling.Profile = CreatePrimary(uiEntity, gambling);
-        // }
-        // else if (clickedId == IDNo) {
-        //     gambling.Profile.Dispose();
-        //     gambling.Purchase = null;;
-        //     gambling.Profile = CreatePrimary(uiEntity, gambling);
-        // }
-        // else if (clickedId == IDExit) {
-        //     gambling.DialogEntity.Set(components.DialogState.NextScriptOp);
-        //     uiEntity.Dispose();
-        // }
+        var uiEntity = Set.GetEntities()[0];
+        ref var gambling = ref uiEntity.Get<components.DialogGambling>();
+
+        if (gambling.CardPurchaseButtons.TryGetValue(clickedId, out var card)) {
+            gambling.Profile.Dispose();
+            gambling.Purchase = card;
+            gambling.Profile = CreateItemProfile(uiEntity, gambling, card);
+        }
+        else if (clickedId == IDYes) {
+            var purchase = gambling.Purchase!;
+
+            var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
+            inventory.Add(purchase.CardId);
+
+            gambling.Profile.Dispose();
+            gambling.Profile = CreatePrimary(uiEntity, gambling);
+        }
+        else if (clickedId == IDNo) {
+            gambling.Profile.Dispose();
+            gambling.Purchase = null;
+            gambling.Profile = CreatePrimary(uiEntity, gambling);
+        }
+        else if (clickedId == IDExit) {
+            gambling.DialogEntity.Set(components.DialogState.NextScriptOp);
+            uiEntity.Dispose();
+        }
     }
 
     protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.DialogGambling component)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -212,9 +212,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
     private string GetSpellPrices(SpellRow card) {
         var sheet = card.Type == 0 ? 5 : 4;
-        return $"{{{fontAlt}{card.PriceA}}}{{{fontAlt}{card.PriceB}}}{{{fontAlt}{card.PriceC}}}";
+        return $"{{{sheet}{card.PriceA}}}{{{sheet}{card.PriceB}}}{{{sheet}{card.PriceC}}}";
     }
-
 
     private const float ButtonOffsetY = -50f;
     private const float RepeatButtonOffsetY = -40f;

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -64,9 +64,9 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         });
         ref var gambling = ref uiEntity.Get<components.DialogGambling>();
 
-        gambling.Profile = CreatePrimary(uiEntity, gambling);
+        gambling.Profile = CreatePrimary(uiEntity, ref gambling);
     }
-    private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, components.DialogGambling gambling)
+    private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, ref components.DialogGambling gambling)
     {
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
@@ -79,6 +79,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             AddTrade(entity, gambling, selectedCard, i, bgRect);
         }
         gambling.RowAnimationTimeLeft = rowAnimationDelay;
+        Console.WriteLine(gambling.RowAnimationTimeLeft);
 
         preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
         preload.CreateSingleButton(entity, new UID(0x91A7E821), IDRepeat, bgRect, offset: 1);
@@ -215,15 +216,15 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         else if (clickedId == IDYes) {
             zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Add(gambling.Purchase!.CardId);
             gambling.Profile.Dispose();
-            gambling.Profile = CreatePrimary(uiEntity, gambling);
+            gambling.Profile = CreatePrimary(uiEntity, ref gambling);
         }
         else if (clickedId == IDNo) {
             gambling.Profile.Dispose();
-            gambling.Profile = CreatePrimary(uiEntity, gambling);
+            gambling.Profile = CreatePrimary(uiEntity, ref gambling);
         }
         else if (clickedId == IDRepeat) {
             gambling.Profile.Dispose();
-            gambling.Profile = CreatePrimary(uiEntity, gambling);
+            gambling.Profile = CreatePrimary(uiEntity, ref gambling);
         }
         else if (clickedId == IDExit) {
             gambling.DialogEntity.Set(components.DialogState.NextScriptOp);
@@ -234,12 +235,10 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.DialogGambling gambling)
     {
         if (gambling.RowAnimationTimeLeft != null) {
-            var newTimeLeft = Math.Max(0f, gambling.RowAnimationTimeLeft - timeElapsed);
-            if (newTimeLeft == 0f) {
+            gambling.RowAnimationTimeLeft -= timeElapsed;
+            if (gambling.RowAnimationTimeLeft <= 0f) {
                 AddRandomTrade();
                 gambling.RowAnimationTimeLeft = rowAnimationDelay;
-            } else {
-                gambling.RowAnimationTimeLeft = newTimeLeft;
             }
         }
     }

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -65,6 +65,9 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         });
         ref var gambling = ref uiEntity.Get<components.DialogGambling>();
 
+        preload.CreateDialogBackground(uiEntity, animateOverlay: false, out var bgRect);
+        gambling.bgRect = bgRect;
+
         gambling.Profile = CreatePrimary(uiEntity, ref gambling);
     }
     private DefaultEcs.Entity CreatePrimary(DefaultEcs.Entity parent, ref components.DialogGambling gambling)
@@ -72,14 +75,11 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
 
-        preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
-        gambling.bgRect = bgRect;
-
         preload.CreateCurrencyLabel(entity, gambling.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         // for (int i = 0; i < rows; i++) {
         //     Random rnd = new();
         //     var selectedCard = gambling.Cards.MinBy(c => rnd.Next());
-        //     AddTrade(entity, gambling, selectedCard, i, bgRect);
+        //     AddTrade(entity, gambling, selectedCard, i);
         // }
         gambling.RowAnimationTimeLeft = rowAnimationDelay;
 
@@ -94,22 +94,19 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
 
-        preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
-        gambling.bgRect = bgRect;
-
         preload.CreateLabel(entity)
-            .With(bgRect.Min + new Vector2(30, 22))
+            .With(gambling.bgRect.Min + new Vector2(30, 22))
             .With(preload.Fnt001)
             .WithText(db.GetText(UIDSpellProfile).Text)
             .Build();
 
         preload.CreateImage(entity)
-            .With(bgRect.Min + new Vector2(50+40, 50+26))
+            .With(gambling.bgRect.Min + new Vector2(50+40, 50+26))
             .With(preload.Spl000, card.CardId.EntityId)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(bgRect.Min + new Vector2(70+40+30, 50+33))
+            .With(gambling.bgRect.Min + new Vector2(70+40+30, 50+33))
             .With(preload.Fnt003)
             .WithText(card.Name)
             .Build();
@@ -128,27 +125,27 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         };
         for (int i = 0; i < texts.Length; i++)
             preload.CreateLabel(entity)
-                .With(bgRect.Min + new Vector2(50+40 + texts[i].col * 90, 100+36 + texts[i].row * 28))
+                .With(gambling.bgRect.Min + new Vector2(50+40 + texts[i].col * 90, 100+36 + texts[i].row * 28))
                 .With(preload.Fnt002)
                 .WithText(texts[i].text)
                 .Build();
 
         preload.CreateLabel(entity)
-            .With(new Vector2(bgRect.Center.X - 76-59, bgRect.Max.Y - 46))
+            .With(new Vector2(gambling.bgRect.Center.X - 76-59, gambling.bgRect.Max.Y - 46))
             .With(preload.Fnt002)
             .WithText(db.GetText(UIDTakeIt).Text)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDYes)
-            .With(new Vector2(bgRect.Center.X + 20-70, bgRect.Max.Y - 65+5))
+            .With(new Vector2(gambling.bgRect.Center.X + 20-70, gambling.bgRect.Max.Y - 65+5))
             .With(new components.ui.ButtonTiles(5, 6))
             .With(preload.Btn000)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDNo)
-            .With(new Vector2(bgRect.Center.X + 56-56, bgRect.Max.Y - 65+5))
+            .With(new Vector2(gambling.bgRect.Center.X + 56-56, gambling.bgRect.Max.Y - 65+5))
             .With(new components.ui.ButtonTiles(7, 8))
             .With(preload.Btn000)
             .Build();
@@ -160,15 +157,15 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         Random rnd = new();
         var selectedCard = gambling.Cards.MinBy(c => rnd.Next());
         gambling.SelectedCards.Add(db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCard));
-        AddTrade(entity, gambling, selectedCard, gambling.SelectedCards.Count-1, gambling.bgRect);
+        AddTrade(entity, ref gambling, selectedCard, gambling.SelectedCards.Count-1);
     }
 
-    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int? selectedCardId, int index, Rect bgRect)
+    private void AddTrade(DefaultEcs.Entity entity, ref components.DialogGambling gambling, int? selectedCardId, int index)
     {
         var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCardId);
 
         var purchase = new components.ui.ElementId(index);
-        var offset = bgRect.Center + new Vector2(25-205, 20-30-120 + 50 * index);
+        var offset = gambling.bgRect.Center + new Vector2(25-205, 20-30-120 + 50 * index);
 
         if (card == null) {
         preload.CreateLabel(entity)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -78,8 +78,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             AddTrade(entity, gambling, selectedCard, i, bgRect);
         }
 
-        CreateSingleButton(entity, new UID(0x91A7E821), 1, IDRepeat, bgRect);
-        CreateSingleButton(entity, new UID(0xF7DFDC21), 0, IDExit, bgRect);
+        preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
+        preload.CreateSingleButton(entity, new UID(0x91A7E821), IDRepeat, bgRect, offset: 1);
 
         return entity;
     }
@@ -194,24 +194,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var className = preload.GetClassText(card.PriceA);
         var prices = preload.GetSpellPrices(card);
         return $"{name}\n{type} - {className} - {prices}";
-    }
-
-    private const float ButtonOffsetY = -50f;
-    private const float RepeatButtonOffsetY = -40f;
-    private void CreateSingleButton(DefaultEcs.Entity entity, UID textUID, int offset, components.ui.ElementId elementId, Rect bgRect)
-    {
-        preload.CreateButton(entity)
-            .With(elementId)
-            .With(new Vector2(bgRect.Center.X, bgRect.Max.Y + ButtonOffsetY + RepeatButtonOffsetY * offset))
-            .With(new components.ui.ButtonTiles(0, 1))
-            .With(components.ui.FullAlignment.TopCenter)
-            .With(preload.Btn000)
-            .WithLabel()
-            .With(preload.Fnt000)
-            .WithText(textUID)
-            .Build();
-
-        // TODO: Set cursor position in dialog gambling
     }
 
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -87,6 +87,11 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
 
+        if (HasCloverleaf())
+            preload.CreateImage(entity)
+                .With(new Vector2(gambling.bgRect.Max.X - 55, gambling.bgRect.Min.Y + 29))
+                .With(db.Items.ElementAt(cloverleafI).CardId)
+                .Build();
         gambling.CurrencyLabel = preload.CreateCurrencyLabel(entity, gambling.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         if (gambling.SelectedCards.Count == rows) {
             RebuildPrimary(entity, ref gambling, allowPurchaseButtons);

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -146,13 +146,21 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
     }
 
-    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int selectedCardId, int index, Rect bgRect)
+    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int? selectedCardId, int index, Rect bgRect)
     {
         var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCardId);
-        if (card == default) return;
 
         var purchase = new components.ui.ElementId(index);
         var offset = bgRect.Center + new Vector2(-205, -120 + 55 * index);
+
+        if (card == null) {
+        preload.CreateLabel(entity)
+            .With(offset + new Vector2(40, 16))
+            .WithText("Blank")
+            .With(preload.Fnt000)
+            .Build();
+            return;
+        };
 
         preload.CreateImage(entity)
             .With(offset)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -201,7 +201,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         Vector2 cardTypeOffset = isAttack ? new(0, 0) : new(0, 28);
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(30, 22))
+            .With(gambling.bgRect.Min + new Vector2(30, 22))
             .With(preload.Fnt001)
             .WithText(db.GetText(UIDSpellProfile).Text)
             .Build();
@@ -225,17 +225,17 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(180, 136 + 28*2))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(180, 192))
             .With(preload.Fnt002)
             .WithLineHeight(28)
             .WithText(SpellValues(card))
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, 136 + (isAttack ? 6 : 4) * 28))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, isAttack ? 300 : 244))
             .With(preload.Fnt000)
             .WithText(card.Info)
-            .WithLineHeight(28)
+            .WithLineHeight(22)
             .WithLineWrap(gambling.bgRect.Size.X - 100)
             .WithAnimation()
             .Build();

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -263,9 +263,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         ref var gambling = ref uiEntity.Get<components.DialogGambling>();
 
         if (gambling.CardPurchaseButtons.TryGetValue(clickedId, out var card)) {
-            gambling.Profile.Dispose();
-            gambling.RowAnimationTimeLeft = null;
             gambling.Purchase = card;
+            gambling.Profile.Dispose();
             gambling.Profile = CreateSpellProfile(uiEntity, ref gambling, card);
         }
         else if (clickedId == IDYes) {
@@ -278,8 +277,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             gambling.Profile = CreatePrimary(uiEntity, ref gambling);
         }
         else if (clickedId == IDRepeat) {
-            gambling.Profile.Dispose();
             gambling.SelectedCards = new();
+            gambling.Profile.Dispose();
             gambling.Profile = CreatePrimary(uiEntity, ref gambling, animate: true);
         }
         else if (clickedId == IDExit) {

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -87,9 +87,9 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         } else {
             for (int i = 0; i < rows; i++) {
                 PullRandomCard(ref gambling);
-                AddTrade(entity, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
+                AddTrade(entity, ref gambling);
                 if (allowTradeButtons)
-                    AddTradeButton(entity, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
+                    AddTradeButton(entity, ref gambling, i);
             }
             preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, gambling.bgRect);
             preload.CreateSingleButton(entity, new UID(0x91A7E821), IDRepeat, gambling.bgRect, offset: 1);
@@ -171,9 +171,10 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         // AddTrade(entity, ref gambling, selectedCard, gambling.SelectedCards.Count-1);
     }
 
-    private void AddTrade(DefaultEcs.Entity entity, ref components.DialogGambling gambling, int? selectedCardId, int index)
+    private void AddTrade(DefaultEcs.Entity entity, ref components.DialogGambling gambling)
     {
-        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCardId);
+        var index = gambling.SelectedCards.Count - 1;
+        var card = gambling.SelectedCards[index];
         var offset = gambling.bgRect.Center + new Vector2(-180, -130 + 50 * index);
 
         if (card == null) {
@@ -198,8 +199,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
     }
 
-    private void AddTradeButton(DefaultEcs.Entity entity, ref components.DialogGambling gambling, int? selectedCardId, int index) {
-        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCardId);
+    private void AddTradeButton(DefaultEcs.Entity entity, ref components.DialogGambling gambling, int index) {
+        var card = gambling.SelectedCards[index];
         var offset = gambling.bgRect.Center + new Vector2(-180, -130 + 50 * index);
         if (card == null) return;
 
@@ -269,7 +270,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
                     // Add one trade, restart timer
                     Pay(ref gambling);
                     PullRandomCard(ref gambling);
-                    AddTrade(gambling.Profile, ref gambling, gambling.SelectedCards.Last()?.CardId.EntityId, gambling.SelectedCards.Count-1);
+                    AddTrade(gambling.Profile, ref gambling);
                     gambling.RowAnimationTimeLeft = rowAnimationDelay;
                 } else {
                     // Add buttons, stop timer
@@ -277,7 +278,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
                     preload.CreateSingleButton(gambling.Profile, new UID(0x91A7E821), IDRepeat, gambling.bgRect, offset: 1);
 
                     for (int i = 0; i < rows; i++) {
-                        AddTradeButton(gambling.Profile, ref gambling, gambling.SelectedCards[i]?.CardId.EntityId, i);
+                        AddTradeButton(gambling.Profile, ref gambling, i);
                     }
                     gambling.RowAnimationTimeLeft = null;
                 }

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -126,31 +126,46 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         }
     }
 
+    private string SpellCountText(SpellRow card) {
+        var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
+        var count = inventory.CountCards(card.CardId);
+        var countInUse = inventory.CountCards(card.CardId, inUse: true);
+
+        if (count == 0){
+            return db.GetText(UIDANewSpell).Text.ToUpper(new CultureInfo("en-US", false));
+        } else {
+            return $"You already have this spell! Number: {count}, in use: {countInUse}";
+        }
+    }
+
     private DefaultEcs.Entity CreateSpellProfile(DefaultEcs.Entity parent, ref components.DialogGambling gambling, SpellRow card)
     {
         var entity = World.CreateEntity();
         entity.Set(new components.Parent(parent));
 
+        var isAttack = card.Type == 0;
+        Vector2 cardTypeOffset = isAttack ? new(0, 0) : new(0, 28);
+
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + new Vector2(30, 22))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(30, 22))
             .With(preload.Fnt001)
             .WithText(db.GetText(UIDSpellProfile).Text)
             .Build();
 
         preload.CreateImage(entity)
-            .With(gambling.bgRect.Min + new Vector2(90, 76))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, 76))
             .With(card.CardId)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + new Vector2(140, 83))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(140, 83))
             .With(preload.Fnt003)
             .WithText(card.Name)
             .Build();
 
         var texts = new (int row, int col, string text)[] {
-            (0, 0, db.GetText(UIDANewSpell).Text.ToUpper(new CultureInfo("en-US", false))),
-            (1, 0, "Offensive Spell - Nature"),
+            (0, 0, SpellCountText(card)),
+            (1, 0, $"{(isAttack ? db.GetText(UIDOffensiveSpell).Text : db.GetText(UIDPassiveSpell).Text)} - {preload.GetClassText(card.PriceA)}"),
             (2, 0, "Mana"),
             (2, 1, "{104}" + (card.Mana == 5 ? "-/-" : $"{card.MaxMana}/{card.MaxMana}")),
             (3, 0, "Level"),
@@ -162,17 +177,17 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         };
         for (int i = 0; i < texts.Length; i++)
             preload.CreateLabel(entity)
-                .With(gambling.bgRect.Min + new Vector2(90 + texts[i].col * 90, 136 + texts[i].row * 28))
+                .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90 + texts[i].col * 90, 136 + texts[i].row * 28))
                 .With(preload.Fnt002)
                 .WithText(texts[i].text)
                 .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + new Vector2(90, 136 + (texts.Last().row + 1) * 28))
+            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, 136 + (texts.Last().row + 1) * 28))
             .With(preload.Fnt000)
             .WithText(card.Info)
             .WithLineHeight(15)
-            .WithLineWrap(gambling.bgRect.Size.X - 140)
+            .WithLineWrap(gambling.bgRect.Size.X - 100)
             .WithAnimation()
             .Build();
 

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -163,7 +163,13 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         var spellType = card.Type == 0 ? db.GetText(UIDOffensiveSpell).Text : db.GetText(UIDPassiveSpell).Text;
         var spellClass = preload.GetClassText(card.PriceA);
         var prices = preload.GetSpellPrices(card);
-        return $"{name}\n{spellType} - {spellClass} - {prices}";
+
+        if (!zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Contains(card.CardId)) {
+            var newSpell = db.GetText(UIDNewSpell).Text.ToUpper(new CultureInfo("en-US", false));
+            return $"{name} - {newSpell}\n{spellType} - {spellClass} - {prices}";
+        } else {
+            return $"{name}\n{spellType} - {spellClass} - {prices}";
+        }
     }
 
     private string TextSpellCount(SpellRow card) {

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -167,6 +167,15 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
                 .Build();
 
         preload.CreateLabel(entity)
+            .With(gambling.bgRect.Min + new Vector2(90, 136 + (texts.Last().row + 1) * 28))
+            .With(preload.Fnt000)
+            .WithText(card.Info)
+            .WithLineHeight(15)
+            .WithLineWrap(gambling.bgRect.Size.X - 140)
+            .WithAnimation()
+            .Build();
+
+        preload.CreateLabel(entity)
             .With(new Vector2(gambling.bgRect.Center.X - 135, gambling.bgRect.Max.Y - 46))
             .With(preload.Fnt002)
             .WithText(db.GetText(UIDTakeIt).Text)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -143,13 +143,11 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
     private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int index, Rect bgRect)
     {
-        // var price = gambling.Cards[index].price;
-        var price = 5;
-        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == gambling.Cards[index].id);
+        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == gambling.Cards[index]);
         if (card == default) return;
 
         var purchase = new components.ui.ElementId(index);
-        var offset = bgRect.Center + new Vector2(-205, -120 + 55 * index);
+        var offset = bgRect.Center + new Vector2(-205, -120 + 10 * index);
 
         preload.CreateImage(entity)
             .With(offset)
@@ -162,26 +160,12 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .With(preload.Fnt002)
             .Build();
 
-        preload.CreateLabel(entity)
-            .With(offset + new Vector2(325, 12))
-            .WithText($"{{0*x}}{price}")
-            .With(preload.Fnt000)
+        preload.CreateButton(entity)
+            .With(purchase)
+            .With(offset + new Vector2(365, 0))
+            .With(new components.ui.ButtonTiles(20, 21))
+            .With(preload.Btn001)
             .Build();
-
-        var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
-        if (inventory.CountCards(gambling.Currency.CardId) >= price) {
-            preload.CreateButton(entity)
-                .With(purchase)
-                .With(offset + new Vector2(365, 0))
-                .With(new components.ui.ButtonTiles(20, 21))
-                .With(preload.Btn001)
-                .Build();
-        } else {
-            preload.CreateImage(entity)
-                .With(offset + new Vector2(365, 0))
-                .With(preload.Btn001, 22)
-                .Build();
-        }
 
         gambling.CardPurchaseButtons[purchase] = card;
     }

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -137,12 +137,12 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         preload.CreateImage(entity)
-            .With(gambling.bgRect.Min + new Vector2(50+40, 50+26))
+            .With(gambling.bgRect.Min + new Vector2(90, 76))
             .With(preload.Spl000, card.CardId.EntityId)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + new Vector2(70+40+30, 50+33))
+            .With(gambling.bgRect.Min + new Vector2(140, 83))
             .With(preload.Fnt003)
             .WithText(card.Name)
             .Build();
@@ -161,27 +161,27 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         };
         for (int i = 0; i < texts.Length; i++)
             preload.CreateLabel(entity)
-                .With(gambling.bgRect.Min + new Vector2(50+40 + texts[i].col * 90, 100+36 + texts[i].row * 28))
+                .With(gambling.bgRect.Min + new Vector2(90 + texts[i].col * 90, 136 + texts[i].row * 28))
                 .With(preload.Fnt002)
                 .WithText(texts[i].text)
                 .Build();
 
         preload.CreateLabel(entity)
-            .With(new Vector2(gambling.bgRect.Center.X - 76-59, gambling.bgRect.Max.Y - 46))
+            .With(new Vector2(gambling.bgRect.Center.X - 135, gambling.bgRect.Max.Y - 46))
             .With(preload.Fnt002)
             .WithText(db.GetText(UIDTakeIt).Text)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDYes)
-            .With(new Vector2(gambling.bgRect.Center.X + 20-70, gambling.bgRect.Max.Y - 65+5))
+            .With(new Vector2(gambling.bgRect.Center.X - 50, gambling.bgRect.Max.Y - 60))
             .With(new components.ui.ButtonTiles(5, 6))
             .With(preload.Btn000)
             .Build();
 
         preload.CreateButton(entity)
             .With(IDNo)
-            .With(new Vector2(gambling.bgRect.Center.X + 56-56, gambling.bgRect.Max.Y - 65+5))
+            .With(new Vector2(gambling.bgRect.Center.X, gambling.bgRect.Max.Y - 60))
             .With(new components.ui.ButtonTiles(7, 8))
             .With(preload.Btn000)
             .Build();
@@ -217,7 +217,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         preload.CreateLabel(entity)
-            .With(offset + new Vector2(49, 16-9))
+            .With(offset + new Vector2(49, 7))
             .WithLineHeight(13)
             .WithText(GetSpellLabel(card))
             .With(preload.Fnt002)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -145,7 +145,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     {
         // var price = gambling.Cards[index].price;
         var price = 5;
-        var card = db.Items.FirstOrDefault(c => c.CardId.EntityId == gambling.Cards[index].id);
+        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == gambling.Cards[index].id);
         if (card == default) return;
 
         var purchase = new components.ui.ElementId(index);
@@ -153,7 +153,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         preload.CreateImage(entity)
             .With(offset)
-            .With(preload.Itm000, card.CardId.EntityId)
+            .With(preload.Spl000, card.CardId.EntityId)
             .Build();
 
         preload.CreateLabel(entity)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -23,6 +23,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
     private readonly int currencyI = 23;
     private readonly int rows = 5;
+    private readonly float rowAnimationDelay = 1f;
 
     private readonly MappedDB db;
     private readonly IDisposable resetUISubscription;
@@ -77,6 +78,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             var selectedCard = gambling.Cards.MinBy(c => rnd.Next());
             AddTrade(entity, gambling, selectedCard, i, bgRect);
         }
+        gambling.RowAnimationTimeLeft = rowAnimationDelay;
 
         preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
         preload.CreateSingleButton(entity, new UID(0x91A7E821), IDRepeat, bgRect, offset: 1);
@@ -148,6 +150,10 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         return entity;
+    }
+
+    private void AddRandomTrade() {
+        Console.WriteLine("random trade added");
     }
 
     private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int? selectedCardId, int index, Rect bgRect)
@@ -225,7 +231,16 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         }
     }
 
-    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.DialogGambling component)
+    protected override void Update(float timeElapsed, in DefaultEcs.Entity entity, ref components.DialogGambling gambling)
     {
+        if (gambling.RowAnimationTimeLeft != null) {
+            var newTimeLeft = Math.Max(0f, gambling.RowAnimationTimeLeft - timeElapsed);
+            if (newTimeLeft == 0f) {
+                AddRandomTrade();
+                gambling.RowAnimationTimeLeft = rowAnimationDelay;
+            } else {
+                gambling.RowAnimationTimeLeft = newTimeLeft;
+            }
+        }
     }
 }

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -15,6 +15,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly components.ui.ElementId IDRepeat = new(1002);
     private static readonly components.ui.ElementId IDExit = new(1003);
 
+    private static readonly UID UIDCannotAfford = new(0x534DCEB1);
     private static readonly UID UIDBlank = new(0x1AF6CAB1);
     private static readonly UID UIDOffensiveSpell = new(0xD4B02981);
     private static readonly UID UIDPassiveSpell = new(0x515E2981);
@@ -112,7 +113,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         preload.CreateLabel(parent)
             .With(gambling.bgRect.Center + new Vector2(0, -3))
             .With(preload.Fnt000)
-            .WithText("You do not have enough money!")
+            .WithText(UIDCannotAfford)
             .With(components.ui.FullAlignment.Center)
             .Build();
         AddBottomButtons(parent, ref gambling);
@@ -223,7 +224,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         preload.CreateLabel(entity)
             .With(gambling.bgRect.Min + new Vector2(30, 22))
             .With(preload.Fnt001)
-            .WithText(db.GetText(UIDSpellProfile).Text)
+            .WithText(UIDSpellProfile)
             .Build();
 
         preload.CreateImage(entity)
@@ -263,7 +264,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         preload.CreateLabel(entity)
             .With(new Vector2(gambling.bgRect.Center.X - 135, gambling.bgRect.Max.Y - 46))
             .With(preload.Fnt002)
-            .WithText(db.GetText(UIDTakeIt).Text)
+            .WithText(UIDTakeIt)
             .Build();
 
         preload.CreateButton(entity)
@@ -299,7 +300,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         if (card == null) {
         preload.CreateLabel(entity)
             .With(offset + new Vector2(40, 16))
-            .WithText(db.GetText(UIDBlank).Text)
+            .WithText(UIDBlank)
             .With(preload.Fnt000)
             .Build();
             return;

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -10,10 +10,16 @@ namespace zzre.game.systems;
 
 public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, messages.DialogGambling>
 {
-    private static readonly components.ui.ElementId IDExit = new(1000);
-    private static readonly components.ui.ElementId IDRepeat = new(1001);
-    private static readonly components.ui.ElementId IDYes = new(1002);
-    private static readonly components.ui.ElementId IDNo = new(1003);
+    private static readonly components.ui.ElementId IDYes = new(1000);
+    private static readonly components.ui.ElementId IDNo = new(1001);
+    private static readonly components.ui.ElementId IDRepeat = new(1002);
+    private static readonly components.ui.ElementId IDExit = new(1003);
+
+    private static readonly UID UIDBlank = new(0x1AF6CAB1);
+    private static readonly UID UIDOffensiveSpell = new(0xD4B02981);
+    private static readonly UID UIDPassiveSpell = new(0x515E2981);
+    private static readonly UID UIDRepeat = new(0x91A7E821);
+    private static readonly UID UIDExit = new(0xF7DFDC21);
 
     private static readonly UID UIDSpellProfile = new(0xBFC6DD81);
     private static readonly UID UIDTakeIt = new(0x84D35581);
@@ -21,9 +27,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly UID UIDOldSpell = new(0x92A1EBB1);
     private static readonly UID UIDOldSpell1 = new(0xE9C9EFB1);
     private static readonly UID UIDOldSpell2 = new(0x8B19EFB1);
-    private static readonly UID UIDOffensiveSpell = new(0xD4B02981);
-    private static readonly UID UIDPassiveSpell = new(0x515E2981);
-    private static readonly UID UIDBlank = new(0x1AF6CAB1);
 
     private static readonly UID UIDMana = new(0x238A3981);
     private static readonly UID UIDLevel = new(0xCDF3D81);
@@ -114,8 +117,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private void AddBottomButtons(DefaultEcs.Entity parent, ref components.DialogGambling gambling)
     {
         if (CanAfford(ref gambling))
-            preload.CreateSingleButton(parent, new UID(0x91A7E821), IDRepeat, gambling.bgRect, offset: 1);
-        preload.CreateSingleButton(parent, new UID(0xF7DFDC21), IDExit, gambling.bgRect);
+            preload.CreateSingleButton(parent, UIDRepeat, IDRepeat, gambling.bgRect, offset: 1);
+        preload.CreateSingleButton(parent, UIDExit, IDExit, gambling.bgRect);
     }
 
     private void AddPurchaseButtons(DefaultEcs.Entity parent, ref components.DialogGambling gambling)
@@ -203,7 +206,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         entity.Set(new components.Parent(parent));
 
         var isAttack = card.Type == 0;
-        Vector2 cardTypeOffset = isAttack ? new(0, 0) : new(0, 28);
 
         preload.CreateLabel(entity)
             .With(gambling.bgRect.Min + new Vector2(30, 22))
@@ -212,32 +214,32 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         preload.CreateImage(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, 76))
+            .With(gambling.bgRect.Min + new Vector2(90, 76 + (isAttack ? 0 : 28)))
             .With(card.CardId)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(140, 83))
+            .With(gambling.bgRect.Min + new Vector2(140, 83 + (isAttack ? 0 : 28)))
             .With(preload.Fnt003)
             .WithText(card.Name)
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, 136))
+            .With(gambling.bgRect.Min + new Vector2(90, 136 + (isAttack ? 0 : 28)))
             .With(preload.Fnt002)
             .WithLineHeight(28)
             .WithText(SpellStats(card))
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(180, 192))
+            .With(gambling.bgRect.Min + new Vector2(180, 192 + (isAttack ? 0 : 28)))
             .With(preload.Fnt002)
             .WithLineHeight(28)
             .WithText(SpellValues(card))
             .Build();
 
         preload.CreateLabel(entity)
-            .With(gambling.bgRect.Min + cardTypeOffset + new Vector2(90, isAttack ? 300 : 244))
+            .With(gambling.bgRect.Min + new Vector2(90, isAttack ? 300 : 272))
             .With(preload.Fnt000)
             .WithText(card.Info)
             .WithLineHeight(22)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -14,8 +14,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly components.ui.ElementId IDYes = new(1002);
     private static readonly components.ui.ElementId IDNo = new(1003);
 
-    private static readonly UID UIDYouHave = new(0x070EE421);
-
     private static readonly UID UIDSpellProfile = new(0xBFC6DD81);
     private static readonly UID UIDTakeIt = new(0x84D35581);
     private static readonly UID UIDANewSpell = new(0xC38FEBB1);
@@ -72,7 +70,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         entity.Set(new components.Parent(parent));
 
         preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
-        CreateTopbar(entity, gambling.Currency);
+        preload.CreateCurrencyLabel(entity, gambling.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         for (int i = 0; i < rows; i++) {
             Random rnd = new Random();
             var selectedCard = gambling.Cards.OrderBy(c => rnd.Next()).First();
@@ -149,17 +147,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         return entity;
-    }
-
-    private void CreateTopbar(DefaultEcs.Entity parent, ItemRow currency)
-    {
-        var amountOwned = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().CountCards(currency.CardId);
-
-        preload.CreateLabel(parent)
-            .With(new Vector2(-60, -170))
-            .With(preload.Fnt000)
-            .WithText($"{db.GetText(UIDYouHave).Text} {{{3000 + currency.CardId.EntityId}}}x{amountOwned}")
-            .Build();
     }
 
     private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int? selectedCardId, int index, Rect bgRect)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Collections.Generic;

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -225,17 +225,12 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             gambling.Profile = CreateSpellProfile(uiEntity, gambling, card);
         }
         else if (clickedId == IDYes) {
-            var purchase = gambling.Purchase!;
-
-            var inventory = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>();
-            inventory.Add(purchase.CardId);
-
+            zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().Add(gambling.Purchase!.CardId);
             gambling.Profile.Dispose();
             gambling.Profile = CreatePrimary(uiEntity, gambling);
         }
         else if (clickedId == IDNo) {
             gambling.Profile.Dispose();
-            gambling.Purchase = null;
             gambling.Profile = CreatePrimary(uiEntity, gambling);
         }
         else if (clickedId == IDRepeat) {

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -138,7 +138,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         preload.CreateImage(entity)
             .With(gambling.bgRect.Min + new Vector2(90, 76))
-            .With(preload.Spl000, card.CardId.EntityId)
+            .With(card.CardId)
             .Build();
 
         preload.CreateLabel(entity)
@@ -213,7 +213,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         preload.CreateImage(entity)
             .With(offset)
-            .With(preload.Spl000, card.CardId.EntityId)
+            .With(card.CardId)
             .Build();
 
         preload.CreateLabel(entity)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -72,8 +72,8 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
         preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
         preload.CreateCurrencyLabel(entity, gambling.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         for (int i = 0; i < rows; i++) {
-            Random rnd = new Random();
-            var selectedCard = gambling.Cards.OrderBy(c => rnd.Next()).First();
+            Random rnd = new();
+            var selectedCard = gambling.Cards.MinBy(c => rnd.Next());
             AddTrade(entity, gambling, selectedCard, i, bgRect);
         }
 
@@ -108,7 +108,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
 
         var texts = new (int row, int col, string text)[] {
-            (0, 0, db.GetText(UIDANewSpell).Text.ToUpper()),
+            (0, 0, db.GetText(UIDANewSpell).Text.ToUpper(new CultureInfo("en-US", false))),
             (1, 0, "Offensive Spell - Nature"),
             (2, 0, "Mana"),
             (2, 1, card.Mana == 5 ? "{{1004}}-/-" : $"{{1004}}{card.MaxMana}/{card.MaxMana}"),
@@ -212,6 +212,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         // TODO: Set cursor position in dialog gambling
     }
+
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)
     {
         var uiEntity = Set.GetEntities()[0];

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -18,6 +18,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly UID UIDYouHave = new(0x070EE421);
 
     private readonly int currencyI = 23;
+    private readonly int rows = 5;
 
     private readonly MappedDB db;
     private readonly IDisposable resetUISubscription;
@@ -67,8 +68,12 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
         CreateTopbar(entity, gambling.Currency);
-        for (int i = 0; i < gambling.Cards.Count; i++)
-            AddTrade(entity, gambling, i, bgRect);
+        for (int i = 0; i < rows; i++) {
+            Random rnd = new Random();
+            var selectedCard = gambling.Cards.OrderBy(c => rnd.Next()).First();
+            AddTrade(entity, gambling, selectedCard, i, bgRect);
+        }
+
         CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
 
         return entity;
@@ -141,13 +146,13 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
             .Build();
     }
 
-    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int index, Rect bgRect)
+    private void AddTrade(DefaultEcs.Entity entity, components.DialogGambling gambling, int selectedCardId, int index, Rect bgRect)
     {
-        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == gambling.Cards[index]);
+        var card = db.Spells.FirstOrDefault(c => c.CardId.EntityId == selectedCardId);
         if (card == default) return;
 
         var purchase = new components.ui.ElementId(index);
-        var offset = bgRect.Center + new Vector2(-205, -120 + 10 * index);
+        var offset = bgRect.Center + new Vector2(-205, -120 + 55 * index);
 
         preload.CreateImage(entity)
             .With(offset)

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -73,6 +73,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
 
         uiEntity.Set(new components.DialogGambling{
             DialogEntity = message.DialogEntity,
+            Currency = db.Items.ElementAt(currencyI),
             Cards = CloverleafFilter(message.Cards),
             SelectedCards = new(),
             CardPurchaseButtons = new()

--- a/zzre/game/systems/dialog/DialogGambling.cs
+++ b/zzre/game/systems/dialog/DialogGambling.cs
@@ -22,22 +22,6 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private static readonly UID UIDOffensiveSpell = new(0xD4B02981);
     private static readonly UID UIDPassiveSpell = new(0x515E2981);
 
-    private static readonly UID[] UIDClassNames = new UID[]
-    {
-        new(0x448DD8A1), // Nature
-        new(0x30D5D8A1), // Air
-        new(0xC15AD8A1), // Water
-        new(0x6EE2D8A1), // Light
-        new(0x44AAD8A1), // Energy
-        new(0xEC31D8A1), // Psi
-        new(0xAD78D8A1), // Stone
-        new(0x6483DCA1), // Ice
-        new(0x8EC9DCA1), // Fire
-        new(0x8313DCA1), // Dark
-        new(0xC659DCA1), // Chaos
-        new(0x3CE1DCA1)  // Metal
-    };
-
     private readonly int currencyI = 23;
     private readonly int rows = 5;
 
@@ -219,7 +203,7 @@ public partial class DialogGambling : ui.BaseScreen<components.DialogGambling, m
     private string GetSpellLabel(SpellRow card) {
         var name = card.Name;
         var type = card.Type == 0 ? "Active Spell" : "Passive Spell";
-        var className = db.GetText(UIDClassNames[card.PriceA-1]).Text;
+        var className = preload.GetClassText(card.PriceA);
         var prices = preload.GetSpellPrices(card);
         return $"{name}\n{type} - {className} - {prices}";
     }

--- a/zzre/game/systems/dialog/DialogScript.cs
+++ b/zzre/game/systems/dialog/DialogScript.cs
@@ -175,6 +175,12 @@ public partial class DialogScript : BaseScript
             entity.Remove<messages.DialogTrading>();
             World.Publish(tradingMessage);
         }
+        else if (entity.TryGet<messages.DialogGambling>(out var gamblingMessage))
+        {
+            Console.WriteLine("published gambling message");
+            entity.Remove<messages.DialogGambling>();
+            World.Publish(gamblingMessage);
+        }
         else
             entity.Set(components.DialogState.WaitForSayString);
     }
@@ -262,8 +268,10 @@ public partial class DialogScript : BaseScript
 
     private void SetupGambling(DefaultEcs.Entity entity, int count, int type, int id)
     {
-        var curMethod = System.Reflection.MethodBase.GetCurrentMethod();
-        Console.WriteLine($"Warning: unimplemented dialog instruction \"{curMethod!.Name}\"");
+        if (!entity.TryGet<messages.DialogGambling>(out var gamblingMessage)){
+            entity.Set(new messages.DialogGambling(entity, new()));
+        }
+        entity.Get<messages.DialogGambling>().Cards.Add((count, id));
     }
 
     private bool IfTriggerIsActive(DefaultEcs.Entity entity, int triggerI)

--- a/zzre/game/systems/dialog/DialogScript.cs
+++ b/zzre/game/systems/dialog/DialogScript.cs
@@ -271,7 +271,8 @@ public partial class DialogScript : BaseScript
         if (!entity.TryGet<messages.DialogGambling>(out var gamblingMessage)){
             entity.Set(new messages.DialogGambling(entity, new()));
         }
-        entity.Get<messages.DialogGambling>().Cards.Add((count, id));
+        for (int i = 0; i < count; i++)
+            entity.Get<messages.DialogGambling>().Cards.Add(id);
     }
 
     private bool IfTriggerIsActive(DefaultEcs.Entity entity, int triggerI)

--- a/zzre/game/systems/dialog/DialogScript.cs
+++ b/zzre/game/systems/dialog/DialogScript.cs
@@ -177,7 +177,6 @@ public partial class DialogScript : BaseScript
         }
         else if (entity.TryGet<messages.DialogGambling>(out var gamblingMessage))
         {
-            Console.WriteLine("published gambling message");
             entity.Remove<messages.DialogGambling>();
             World.Publish(gamblingMessage);
         }

--- a/zzre/game/systems/dialog/DialogScript.cs
+++ b/zzre/game/systems/dialog/DialogScript.cs
@@ -272,7 +272,7 @@ public partial class DialogScript : BaseScript
             entity.Set(new messages.DialogGambling(entity, new()));
         }
         for (int i = 0; i < count; i++)
-            entity.Get<messages.DialogGambling>().Cards.Add(id);
+            entity.Get<messages.DialogGambling>().Cards.Add(type == 1 ? id : null);
     }
 
     private bool IfTriggerIsActive(DefaultEcs.Entity entity, int triggerI)

--- a/zzre/game/systems/dialog/DialogTalk.cs
+++ b/zzre/game/systems/dialog/DialogTalk.cs
@@ -56,9 +56,9 @@ public partial class DialogTalk : ui.BaseScreen<components.DialogTalk, messages.
         var talkLabels = message.DialogEntity.TryGet<components.DialogTalkLabels>()
             .GetValueOrDefault(components.DialogTalkLabels.Exit);
         if (talkLabels == components.DialogTalkLabels.Exit)
-            preload.CreateSingleButton(uiEntity, new UID(0xF7DFDC21), IDExit, bgRect);
+            preload.CreateSingleDialogButton(uiEntity, new UID(0xF7DFDC21), IDExit, bgRect);
         else if (talkLabels == components.DialogTalkLabels.Continue)
-            preload.CreateSingleButton(uiEntity, new UID(0xCABAD411), IDContinue, bgRect);
+            preload.CreateSingleDialogButton(uiEntity, new UID(0xCABAD411), IDContinue, bgRect);
         else
             CreateYesNoButtons(uiEntity, bgRect);
     }

--- a/zzre/game/systems/dialog/DialogTalk.cs
+++ b/zzre/game/systems/dialog/DialogTalk.cs
@@ -56,9 +56,9 @@ public partial class DialogTalk : ui.BaseScreen<components.DialogTalk, messages.
         var talkLabels = message.DialogEntity.TryGet<components.DialogTalkLabels>()
             .GetValueOrDefault(components.DialogTalkLabels.Exit);
         if (talkLabels == components.DialogTalkLabels.Exit)
-            CreateSingleButton(uiEntity, new UID(0xF7DFDC21), IDExit, bgRect);
+            preload.CreateSingleButton(uiEntity, new UID(0xF7DFDC21), IDExit, bgRect);
         else if (talkLabels == components.DialogTalkLabels.Continue)
-            CreateSingleButton(uiEntity, new UID(0xCABAD411), IDContinue, bgRect);
+            preload.CreateSingleButton(uiEntity, new UID(0xCABAD411), IDContinue, bgRect);
         else
             CreateYesNoButtons(uiEntity, bgRect);
     }
@@ -135,22 +135,6 @@ public partial class DialogTalk : ui.BaseScreen<components.DialogTalk, messages.
 
     private const float YesNoButtonOffsetX = 4f;
     private const float ButtonOffsetY = -50f;
-    private void CreateSingleButton(DefaultEcs.Entity parent, UID textUID, components.ui.ElementId elementId, Rect bgRect)
-    {
-        preload.CreateButton(parent)
-            .With(elementId)
-            .With(new Vector2(bgRect.Center.X, bgRect.Max.Y + ButtonOffsetY))
-            .With(new components.ui.ButtonTiles(0, 1))
-            .With(components.ui.FullAlignment.TopCenter)
-            .With(preload.Btn000)
-            .WithLabel()
-            .With(preload.Fnt000)
-            .WithText(textUID)
-            .Build();
-
-        // TODO: Set cursor position in dialog talk
-    }
-
     private void CreateYesNoButtons(DefaultEcs.Entity parent, Rect bgRect)
     {
         preload.CreateButton(parent)

--- a/zzre/game/systems/dialog/DialogTrading.cs
+++ b/zzre/game/systems/dialog/DialogTrading.cs
@@ -15,7 +15,6 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
 
     private static readonly UID UIDPurchaseItem = new(0x7B973CA1);
     private static readonly UID UIDItemProfile = new(0x2C2084B1);
-    private static readonly UID UIDYouHave = new(0x070EE421);
 
     private readonly MappedDB db;
     private readonly IDisposable resetUISubscription;
@@ -65,7 +64,7 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
         entity.Set(new components.Parent(parent));
 
         preload.CreateDialogBackground(entity, animateOverlay: false, out var bgRect);
-        CreateTopbar(entity, trading.Currency);
+        preload.CreateCurrencyLabel(entity, trading.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         for (int i = 0; i < trading.CardTrades.Count; i++)
             AddTrade(entity, trading, i, bgRect);
         CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
@@ -127,17 +126,6 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
             .Build();
 
         return entity;
-    }
-
-    private void CreateTopbar(DefaultEcs.Entity parent, ItemRow currency)
-    {
-        var amountOwned = zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>().CountCards(currency.CardId);
-
-        preload.CreateLabel(parent)
-            .With(new Vector2(-60, -170))
-            .With(preload.Fnt000)
-            .WithText($"{db.GetText(UIDYouHave).Text} {{{3000 + currency.CardId.EntityId}}}x{amountOwned}")
-            .Build();
     }
 
     private void AddTrade(DefaultEcs.Entity entity, components.DialogTrading trading, int index, Rect bgRect)

--- a/zzre/game/systems/dialog/DialogTrading.cs
+++ b/zzre/game/systems/dialog/DialogTrading.cs
@@ -67,7 +67,7 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
         preload.CreateCurrencyLabel(entity, trading.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         for (int i = 0; i < trading.CardTrades.Count; i++)
             AddTrade(entity, trading, i, bgRect);
-        CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
+        preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
 
         return entity;
     }
@@ -171,22 +171,6 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
         trading.CardPurchaseButtons[purchase] = card;
     }
 
-    private const float ButtonOffsetY = -50f;
-    private void CreateSingleButton(DefaultEcs.Entity entity, UID textUID, components.ui.ElementId elementId, Rect bgRect)
-    {
-        preload.CreateButton(entity)
-            .With(elementId)
-            .With(new Vector2(bgRect.Center.X, bgRect.Max.Y + ButtonOffsetY))
-            .With(new components.ui.ButtonTiles(0, 1))
-            .With(components.ui.FullAlignment.TopCenter)
-            .With(preload.Btn000)
-            .WithLabel()
-            .With(preload.Fnt000)
-            .WithText(textUID)
-            .Build();
-
-        // TODO: Set cursor position in dialog trading
-    }
     private void HandleElementDown(DefaultEcs.Entity entity, components.ui.ElementId clickedId)
     {
         var uiEntity = Set.GetEntities()[0];

--- a/zzre/game/systems/dialog/DialogTrading.cs
+++ b/zzre/game/systems/dialog/DialogTrading.cs
@@ -67,7 +67,7 @@ public partial class DialogTrading : ui.BaseScreen<components.DialogTrading, mes
         preload.CreateCurrencyLabel(entity, trading.Currency, zanzarah.CurrentGame!.PlayerEntity.Get<Inventory>());
         for (int i = 0; i < trading.CardTrades.Count; i++)
             AddTrade(entity, trading, i, bgRect);
-        preload.CreateSingleButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
+        preload.CreateSingleDialogButton(entity, new UID(0xF7DFDC21), IDExit, bgRect);
 
         return entity;
     }

--- a/zzre/game/systems/ui/ScrBookMenu.cs
+++ b/zzre/game/systems/ui/ScrBookMenu.cs
@@ -20,21 +20,6 @@ public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, message
         new(0xB031B8B1), // Jump Ability
         new(0xB6CA5A11)  // Special
     };
-    private static readonly UID[] UIDClassNames = new UID[]
-    {
-        new(0x448DD8A1), // Nature
-        new(0x30D5D8A1), // Air
-        new(0xC15AD8A1), // Water
-        new(0x6EE2D8A1), // Light
-        new(0x44AAD8A1), // Energy
-        new(0xEC31D8A1), // Psi
-        new(0xAD78D8A1), // Stone
-        new(0x6483DCA1), // Ice
-        new(0x8EC9DCA1), // Fire
-        new(0x8313DCA1), // Dark
-        new(0xC659DCA1), // Chaos
-        new(0x3CE1DCA1)  // Metal
-    };
     private static readonly UID UIDEvol = new (0x69226721); // Evolution at level
 
     public ScrBookMenu(ITagContainer diContainer) : base(diContainer, BlockFlags.All)
@@ -133,7 +118,7 @@ public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, message
 
         preload.CreateLabel(entity)
             .With(Mid + new Vector2(36, 80))
-            .WithText(db.GetText(UIDClassNames[(int)fairyRow.Class0-1]).Text)
+            .WithText(preload.GetClassText((int)fairyRow.Class0))
             .With(preload.Fnt002)
             .Build();
 

--- a/zzre/game/systems/ui/ScrBookMenu.cs
+++ b/zzre/game/systems/ui/ScrBookMenu.cs
@@ -170,7 +170,7 @@ public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, message
 
         preload.CreateLabel(entity)
             .With(Mid + new Vector2(111, 266 + index*17))
-            .WithText(string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value)))
+            .WithText(preload.GetLightsIndicator(value))
             .With(preload.Fnt001)
             .Build();
     }

--- a/zzre/game/systems/ui/ScrBookMenu.cs
+++ b/zzre/game/systems/ui/ScrBookMenu.cs
@@ -118,7 +118,7 @@ public partial class ScrBookMenu : BaseScreen<components.ui.ScrBookMenu, message
 
         preload.CreateLabel(entity)
             .With(Mid + new Vector2(36, 80))
-            .WithText(preload.GetClassText((int)fairyRow.Class0))
+            .WithText(preload.GetClassText(fairyRow.Class0))
             .With(preload.Fnt002)
             .Build();
 

--- a/zzre/game/systems/ui/ScrDeck.cs
+++ b/zzre/game/systems/ui/ScrDeck.cs
@@ -358,8 +358,7 @@ public partial class ScrDeck : BaseScreen<components.ui.ScrDeck, messages.ui.Ope
     {
         var dbSpell = mappedDB.GetSpell(spell.dbUID);
         var mana = dbSpell.Mana == 5 ? "-/-" : $"{spell.mana}/{dbSpell.MaxMana}";
-        var sheet = dbSpell.Type == 0 ? '5' : '4';
-        return $"{dbSpell.Name}\n{{104}}{mana} {{{sheet}{dbSpell.PriceA}}}{{{sheet}{dbSpell.PriceB}}}{{{sheet}{dbSpell.PriceC}}}";
+        return $"{dbSpell.Name}\n{{104}}{mana} {preload.GetSpellPrices(dbSpell)}";
     }
 
     private void CreateFairyInfos(DefaultEcs.Entity entity, ref components.ui.ScrDeck deck)

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Numerics;
 using DefaultEcs.Resource;
 using zzio;
+using zzio.db;
 using zzre.rendering;
 
 namespace zzre.game.systems.ui;
@@ -204,4 +206,13 @@ public class UIPreloader
             InDuration: 0.3f,
             SustainDelay: 0.03f, // this ensures we have at least one frame of pure black to switch scenes/locations
             OutDuration: 0.3f));
+
+    public string GetSpellPrices(SpellRow spellRow) {
+        var sheet = spellRow.Type == 0 ? 5 : 4;
+        return $"{{{sheet}{spellRow.PriceA}}}{{{sheet}{spellRow.PriceB}}}{{{sheet}{spellRow.PriceC}}}";
+    }
+
+    public string GetLightsIndicator(int value) {
+        return string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value));
+    }
 }

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -233,7 +233,7 @@ public class UIPreloader
 
     private const float ButtonOffsetY = -50f;
     private const float RepeatButtonOffsetY = -40f;
-    public DefaultEcs.Entity CreateSingleButton(DefaultEcs.Entity entity, UID textUID, components.ui.ElementId elementId, Rect bgRect, int offset = 0)
+    public DefaultEcs.Entity CreateSingleDialogButton(DefaultEcs.Entity entity, UID textUID, components.ui.ElementId elementId, Rect bgRect, int offset = 0)
     {
         var button = CreateButton(entity)
             .With(elementId)

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -57,6 +57,7 @@ public class UIPreloader
         new(0xC659DCA1), // Chaos
         new(0x3CE1DCA1)  // Metal
     };
+    private static readonly UID UIDYouHave = new(0x070EE421);
 
     public UIPreloader(ITagContainer diContainer)
     {
@@ -222,6 +223,13 @@ public class UIPreloader
             InDuration: 0.3f,
             SustainDelay: 0.03f, // this ensures we have at least one frame of pure black to switch scenes/locations
             OutDuration: 0.3f));
+
+    public DefaultEcs.Entity CreateCurrencyLabel(DefaultEcs.Entity parent, ItemRow currency, Inventory inventory) =>
+        CreateLabel(parent)
+            .With(new Vector2(-60, -170))
+            .With(Fnt000)
+            .WithText($"{GetDBText(UIDYouHave)} {{{3000 + currency.CardId.EntityId}}}x{inventory.CountCards(currency.CardId)}")
+            .Build();
 
     public string GetSpellPrices(SpellRow spellRow) {
         var sheet = spellRow.Type == 0 ? 5 : 4;

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -44,18 +44,6 @@ public class UIPreloader
 
     private static readonly UID[] UIDClassNames = new UID[]
     {
-        new(0x448DD8A1), // Nature
-        new(0x30D5D8A1), // Air
-        new(0xC15AD8A1), // Water
-        new(0x6EE2D8A1), // Light
-        new(0x44AAD8A1), // Energy
-        new(0xEC31D8A1), // Psi
-        new(0xAD78D8A1), // Stone
-        new(0x6483DCA1), // Ice
-        new(0x8EC9DCA1), // Fire
-        new(0x8313DCA1), // Dark
-        new(0xC659DCA1), // Chaos
-        new(0x3CE1DCA1)  // Metal
     };
     private static readonly UID UIDYouHave = new(0x070EE421);
 
@@ -252,13 +240,26 @@ public class UIPreloader
 
     public string GetSpellPrices(SpellRow spellRow) {
         var sheet = spellRow.Type == 0 ? 5 : 4;
-        return $"{{{sheet}{spellRow.PriceA}}}{{{sheet}{spellRow.PriceB}}}{{{sheet}{spellRow.PriceC}}}";
+        return $"{{{sheet}{(int)spellRow.PriceA}}}{{{sheet}{(int)spellRow.PriceB}}}{{{sheet}{(int)spellRow.PriceC}}}";
     }
 
     public string GetLightsIndicator(int value) {
         return string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value));
     }
 
-    public string GetClassText(int Class0) =>
-        GetDBText(UIDClassNames[Class0-1]);
+    public string GetClassText(ZZClass zzClass) => zzClass switch {
+        ZZClass.Nature  => GetDBText(new UID(0x448DD8A1)), // Nature
+        ZZClass.Air     => GetDBText(new UID(0x30D5D8A1)), // Air
+        ZZClass.Water   => GetDBText(new UID(0xC15AD8A1)), // Water
+        ZZClass.Light   => GetDBText(new UID(0x6EE2D8A1)), // Light
+        ZZClass.Energy  => GetDBText(new UID(0x44AAD8A1)), // Energy
+        ZZClass.Mental  => GetDBText(new UID(0xEC31D8A1)), // Psi
+        ZZClass.Stone   => GetDBText(new UID(0xAD78D8A1)), // Stone
+        ZZClass.Ice     => GetDBText(new UID(0x6483DCA1)), // Ice
+        ZZClass.Fire    => GetDBText(new UID(0x8EC9DCA1)), // Fire
+        ZZClass.Dark    => GetDBText(new UID(0x8313DCA1)), // Dark
+        ZZClass.Chaos   => GetDBText(new UID(0xC659DCA1)), // Chaos
+        ZZClass.Metal   => GetDBText(new UID(0x3CE1DCA1)), // Metal
+        _ => throw new ArgumentException($"Unknown spell class: {zzClass}")
+    };
 }

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -231,6 +231,25 @@ public class UIPreloader
             .WithText($"{GetDBText(UIDYouHave)} {{{3000 + currency.CardId.EntityId}}}x{inventory.CountCards(currency.CardId)}")
             .Build();
 
+    private const float ButtonOffsetY = -50f;
+    private const float RepeatButtonOffsetY = -40f;
+    public DefaultEcs.Entity CreateSingleButton(DefaultEcs.Entity entity, UID textUID, components.ui.ElementId elementId, Rect bgRect, int offset = 0)
+    {
+        var button = CreateButton(entity)
+            .With(elementId)
+            .With(new Vector2(bgRect.Center.X, bgRect.Max.Y + ButtonOffsetY + RepeatButtonOffsetY * offset))
+            .With(new components.ui.ButtonTiles(0, 1))
+            .With(components.ui.FullAlignment.TopCenter)
+            .With(Btn000)
+            .WithLabel()
+            .With(Fnt000)
+            .WithText(textUID)
+            .Build();
+
+        // TODO: Set cursor position in dialog gambling
+        return button;
+    }
+
     public string GetSpellPrices(SpellRow spellRow) {
         var sheet = spellRow.Type == 0 ? 5 : 4;
         return $"{{{sheet}{spellRow.PriceA}}}{{{sheet}{spellRow.PriceB}}}{{{sheet}{spellRow.PriceC}}}";

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -42,9 +42,6 @@ public class UIPreloader
         Cls001,
         Map000;
 
-    private static readonly UID[] UIDClassNames = new UID[]
-    {
-    };
     private static readonly UID UIDYouHave = new(0x070EE421);
 
     public UIPreloader(ITagContainer diContainer)

--- a/zzre/game/systems/ui/UIPreloader.cs
+++ b/zzre/game/systems/ui/UIPreloader.cs
@@ -42,6 +42,22 @@ public class UIPreloader
         Cls001,
         Map000;
 
+    private static readonly UID[] UIDClassNames = new UID[]
+    {
+        new(0x448DD8A1), // Nature
+        new(0x30D5D8A1), // Air
+        new(0xC15AD8A1), // Water
+        new(0x6EE2D8A1), // Light
+        new(0x44AAD8A1), // Energy
+        new(0xEC31D8A1), // Psi
+        new(0xAD78D8A1), // Stone
+        new(0x6483DCA1), // Ice
+        new(0x8EC9DCA1), // Fire
+        new(0x8313DCA1), // Dark
+        new(0xC659DCA1), // Chaos
+        new(0x3CE1DCA1)  // Metal
+    };
+
     public UIPreloader(ITagContainer diContainer)
     {
         UIWorld = diContainer.GetTag<DefaultEcs.World>();
@@ -215,4 +231,7 @@ public class UIPreloader
     public string GetLightsIndicator(int value) {
         return string.Concat(Enumerable.Repeat("{1017}", value)) + string.Concat(Enumerable.Repeat("{1018}", 5-value));
     }
+
+    public string GetClassText(int Class0) =>
+        GetDBText(UIDClassNames[Class0-1]);
 }


### PR DESCRIPTION
- [x] Primary profile
- [x] Spell profile
- [x] Not enough currency profile
- [x] Animation
- [x] Currency spending during animation
- [x] Refactoring to unify some gambling and trading code

~~Known outstanding issue: clicking during animation causes animation to restart, caused by HandleElementDown always triggering when no hoverable elements are present.~~ fixed in [068c87b](https://github.com/Helco/zzio/commit/068c87becfc087d82615df91644c71116fb3d16e)