### PR TITLE
zzre: Migrate to Veldrid fork of TechPizzaDev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nuget-feed
 **/*.user
 **/BuildOutput.sarif
 sarif-output
+**/.DS_Store

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Common Dependency versioning -->
     <PropertyGroup>
         <RestoreSources>$(RestoreSources);../nuget-feed;https://api.nuget.org/v3/index.json</RestoreSources>
-        <VeldridHash>g603c7f2521</VeldridHash>
+        <VeldridHash>g717ab09d7a</VeldridHash>
         <DefaultEcsHash>0e92bb5</DefaultEcsHash>
         <ImguiHash>9b51cce</ImguiHash>
         <MlangHash>331cf83</MlangHash>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Common Dependency versioning -->
     <PropertyGroup>
         <RestoreSources>$(RestoreSources);../nuget-feed;https://api.nuget.org/v3/index.json</RestoreSources>
-        <VeldridHash>g717ab09d7a</VeldridHash>
+        <VeldridHash>g9c18bddece</VeldridHash>
         <DefaultEcsHash>0e92bb5</DefaultEcsHash>
         <ImguiHash>9b51cce</ImguiHash>
         <MlangHash>331cf83</MlangHash>

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -33,14 +33,14 @@ MlangHash=`git -C extern/Mlang rev-parse --short HEAD`
 NLayerHash=`git -C extern/NLayer rev-parse --short HEAD`
 Configuration=Release
 ConfigSuffix=
-VeldridHash=notactuallyused
+VeldridHash=4.9.0-717ab09d
 CommonFlags="--include-symbols -p:EmbedAllSources=true -p:DebugType=portable -p:SymbolPackageFormat=snupkg -clp:ErrorsOnly -o nuget-feed"
 
 dotnet pack extern/DefaultEcs/source/DefaultEcs/DefaultEcs.csproj -c SafeDebug $CommonFlags "-p:TEST=true" --version-suffix safe-$DefaultEcsHash
 dotnet pack extern/DefaultEcs/source/DefaultEcs/DefaultEcs.csproj -c $Configuration $CommonFlags "-p:TEST=true" --version-suffix $DefaultEcsHash$ConfigSuffix
-dotnet pack extern/Veldrid/src/Veldrid/Veldrid.csproj -c $Configuration $CommonFlags "-p:ExcludeOpenGL=true" "-p:ExcludeD3D11=true" --version-suffix $VeldridHash$ConfigSuffix
-dotnet pack extern/Veldrid/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj -c $Configuration $CommonFlags --version-suffix $VeldridHash$ConfigSuffix
-dotnet pack extern/Veldrid/src/Veldrid.RenderDoc/Veldrid.RenderDoc.csproj -c $Configuration $CommonFlags --version-suffix $VeldridHash$ConfigSuffix
+dotnet pack extern/Veldrid/src/Veldrid/Veldrid.csproj -c $Configuration $CommonFlags "-p:ExcludeOpenGL=true" "-p:ExcludeD3D11=true" "-p:ExcludeMetal=true"
+dotnet pack extern/Veldrid/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj -c $Configuration $CommonFlags
+dotnet pack extern/Veldrid/src/Veldrid.RenderDoc/Veldrid.RenderDoc.csproj -c $Configuration $CommonFlags
 dotnet pack extern/ImGui.NET/src/ImGui.NET/ImGui.NET.csproj -c $Configuration $CommonFlags -p:PackagePrereleaseIdentifier=-$ImGuiNETHash$ConfigSuffix
 dotnet pack extern/ImGui.NET/src/ImGuizmo.NET/ImGuizmo.NET.csproj -c $Configuration $CommonFlags -p:PackagePrereleaseIdentifier=-$ImGuiNETHash$ConfigSuffix
 dotnet pack extern/Mlang/Mlang/Mlang.csproj -c $Configuration $CommonFlags --version-suffix $MlangHash

--- a/zzre.core/imgui/FramebufferArea.cs
+++ b/zzre.core/imgui/FramebufferArea.cs
@@ -48,12 +48,12 @@ public class FramebufferArea : BaseDisposable
     protected override void DisposeManaged()
     {
         base.DisposeManaged();
+        if (bindingHandle != IntPtr.Zero)
+            ImGuiRenderer.RemoveImGuiBinding(targetColor);
         WindowContainer.OnceBeforeUpdate += () =>
         {
-            // Delay disposal so we do not attempt to render the ImGui commands
-            // with the framebuffer texture already disposed
-            if (bindingHandle != IntPtr.Zero)
-                ImGuiRenderer.RemoveImGuiBinding(targetColor);
+            // Delay disposal so we do not attempt to dispose resources
+            // that are still in-flight
             bindingHandle = IntPtr.Zero;
             targetColor.Dispose();
             targetDepth.Dispose();

--- a/zzre.core/imgui/ImGuiRenderer.cs
+++ b/zzre.core/imgui/ImGuiRenderer.cs
@@ -133,12 +133,12 @@ namespace zzre.imgui
             _gd = gd;
             _colorSpaceHandling = colorSpaceHandling;
             ResourceFactory factory = gd.ResourceFactory;
-            _vertexBuffer = factory.CreateBuffer(new BufferDescription(10000, BufferUsage.VertexBuffer | BufferUsage.Dynamic));
+            _vertexBuffer = factory.CreateBuffer(new BufferDescription(10000, BufferUsage.VertexBuffer | BufferUsage.DynamicWrite));
             _vertexBuffer.Name = "ImGui.NET Vertex Buffer";
-            _indexBuffer = factory.CreateBuffer(new BufferDescription(2000, BufferUsage.IndexBuffer | BufferUsage.Dynamic));
+            _indexBuffer = factory.CreateBuffer(new BufferDescription(2000, BufferUsage.IndexBuffer | BufferUsage.DynamicWrite));
             _indexBuffer.Name = "ImGui.NET Index Buffer";
 
-            _projMatrixBuffer = factory.CreateBuffer(new BufferDescription(64, BufferUsage.UniformBuffer | BufferUsage.Dynamic));
+            _projMatrixBuffer = factory.CreateBuffer(new BufferDescription(64, BufferUsage.UniformBuffer | BufferUsage.DynamicWrite));
             _projMatrixBuffer.Name = "ImGui.NET Projection Buffer";
 
             byte[] vertexShaderBytes = GetEmbeddedResourceBytes("imgui-vertex");
@@ -179,7 +179,7 @@ namespace zzre.imgui
                 [_layout, _textureLayout],
                 outputDescription,
                 ResourceBindingModel.Default);
-            _pipeline = factory.CreateGraphicsPipeline(ref pd);
+            _pipeline = factory.CreateGraphicsPipeline(pd);
             _pipeline.Name = "ImGui.NET Pipeline";
 
             _mainResourceSet = factory.CreateResourceSet(new ResourceSetDescription(_layout,
@@ -628,7 +628,7 @@ namespace zzre.imgui
             if (totalVBSize > _vertexBuffer.SizeInBytes)
             {
                 _vertexBuffer.Dispose();
-                _vertexBuffer = gd.ResourceFactory.CreateBuffer(new BufferDescription((uint)(totalVBSize * 1.5f), BufferUsage.VertexBuffer | BufferUsage.Dynamic));
+                _vertexBuffer = gd.ResourceFactory.CreateBuffer(new BufferDescription((uint)(totalVBSize * 1.5f), BufferUsage.VertexBuffer | BufferUsage.DynamicWrite));
                 _vertexBuffer.Name = $"ImGui.NET Vertex Buffer";
             }
 
@@ -636,7 +636,7 @@ namespace zzre.imgui
             if (totalIBSize > _indexBuffer.SizeInBytes)
             {
                 _indexBuffer.Dispose();
-                _indexBuffer = gd.ResourceFactory.CreateBuffer(new BufferDescription((uint)(totalIBSize * 1.5f), BufferUsage.IndexBuffer | BufferUsage.Dynamic));
+                _indexBuffer = gd.ResourceFactory.CreateBuffer(new BufferDescription((uint)(totalIBSize * 1.5f), BufferUsage.IndexBuffer | BufferUsage.DynamicWrite));
                 _indexBuffer.Name = $"ImGui.NET Index Buffer";
             }
 

--- a/zzre.core/imgui/ImGuiRenderer.cs
+++ b/zzre.core/imgui/ImGuiRenderer.cs
@@ -258,15 +258,8 @@ namespace zzre.imgui
         /// <summary>
         /// Retrieves the shader texture binding for the given helper handle.
         /// </summary>
-        public ResourceSet GetImageResourceSet(IntPtr imGuiBinding)
-        {
-            if (!_viewsById.TryGetValue(imGuiBinding, out ResourceSetInfo rsi))
-            {
-                throw new InvalidOperationException("No registered ImGui binding with id " + imGuiBinding.ToString());
-            }
-
-            return rsi.ResourceSet;
-        }
+        private ResourceSet GetImageResourceSet(IntPtr imGuiBinding) =>
+            _viewsById.GetValueOrDefault(imGuiBinding).ResourceSet;
 
         public void ClearCachedImageResources()
         {
@@ -705,7 +698,10 @@ namespace zzre.imgui
                             }
                             else
                             {
-                                cl.SetGraphicsResourceSet(1, GetImageResourceSet(pcmd.TextureId));
+                                var resourceSet = GetImageResourceSet(pcmd.TextureId);
+                                if (resourceSet == null)
+                                    continue;
+                                cl.SetGraphicsResourceSet(1, resourceSet);
                             }
                         }
 

--- a/zzre.core/imgui/WindowContainer.cs
+++ b/zzre.core/imgui/WindowContainer.cs
@@ -50,7 +50,7 @@ public class WindowContainer : BaseDisposable, IReadOnlyCollection<BaseWindow>
     {
         Device = device;
 
-        var fb = device.MainSwapchain.Framebuffer;
+        var fb = device.MainSwapchain!.Framebuffer;
         ImGuiRenderer = new(device, fb.OutputDescription, (int)fb.Width, (int)fb.Height, ColorSpaceHandling.Legacy, callNewFrame: false);
         ImGuizmoNET.ImGuizmo.SetImGuiContext(ImGui.GetCurrentContext());
         ImGuizmoNET.ImGuizmo.AllowAxisFlip(false);
@@ -186,7 +186,7 @@ public class WindowContainer : BaseDisposable, IReadOnlyCollection<BaseWindow>
                 Device.WaitForFence(fence);
             fence.Reset();
             commandList.Begin();
-            commandList.SetFramebuffer(Device.MainSwapchain.Framebuffer);
+            commandList.SetFramebuffer(Device.MainSwapchain!.Framebuffer);
             commandList.ClearColorTarget(0, RgbaFloat.Cyan);
             ImGuiRenderer.Render(Device, commandList);
             commandList.End();

--- a/zzre.core/rendering/BaseMaterial.cs
+++ b/zzre.core/rendering/BaseMaterial.cs
@@ -48,7 +48,7 @@ public class BaseMaterial : BaseDisposable, IMaterial
                 resourceSet = factory.CreateResourceSet(new ResourceSetDescription()
                 {
                     Layout = layout,
-                    BoundResources = Bindings.Select(b => b.Resource).ToArray()
+                    BoundResources = Bindings.Select(b => b.Resource).ToArray()!
                 });
                 resourceSet.Name = $"{parentName} Set {index}";
             }

--- a/zzre.core/rendering/DynamicGraphicsBuffer.cs
+++ b/zzre.core/rendering/DynamicGraphicsBuffer.cs
@@ -151,7 +151,7 @@ public class DynamicGraphicsBuffer : BaseDisposable
         foreach (var range in dirtyBytes)
         {
             var offset = range.GetOffset(capacityInBytes);
-            cl.UpdateBuffer(OptionalBuffer, (uint)offset, bytes.AsSpan(range));
+            cl.UpdateBuffer(OptionalBuffer!, (uint)offset, bytes.AsSpan(range));
         }
         dirtyBytes.Clear();
     }

--- a/zzre.core/rendering/DynamicMesh.cs
+++ b/zzre.core/rendering/DynamicMesh.cs
@@ -28,7 +28,7 @@ public class DynamicMesh : BaseDisposable, IVertexAttributeContainer
         {
             Name = name;
             buffer = new(device,
-                BufferUsage.VertexBuffer | (dynamic ? BufferUsage.Dynamic : default),
+                BufferUsage.VertexBuffer | (dynamic ? BufferUsage.DynamicWrite : default),
                 $"{meshName} {name}",
                 minGrowFactor)
             {
@@ -82,7 +82,7 @@ public class DynamicMesh : BaseDisposable, IVertexAttributeContainer
         this.minGrowFactor = minGrowFactor;
 
         indexBuffer = new(graphicsDevice,
-            BufferUsage.IndexBuffer | (dynamic ? BufferUsage.Dynamic : default),
+            BufferUsage.IndexBuffer | (dynamic ? BufferUsage.DynamicWrite : default),
             name + " Indices",
             minGrowFactor)
         {

--- a/zzre.core/rendering/MlangMaterial.cs
+++ b/zzre.core/rendering/MlangMaterial.cs
@@ -110,7 +110,7 @@ public class MlangMaterial : BaseDisposable, IMaterial
                     throw new InvalidOperationException($"Binding {bindingInfo.Name} is not set");
                 setDescriptions[bindingInfo.SetIndex].BoundResources[bindingInfo.BindingIndex] = binding.Resource;
             }
-            resourceSets = setDescriptions.Select(Device.ResourceFactory.CreateResourceSet).ToArray();
+            resourceSets = setDescriptions.Select(d => Device.ResourceFactory.CreateResourceSet(d)).ToArray();
         }
         for (int i = 0; i < resourceSets.Length; i++)
             cl.SetGraphicsResourceSet((uint)i, resourceSets[i]);

--- a/zzre.core/rendering/ShaderVariantCollection.cs
+++ b/zzre.core/rendering/ShaderVariantCollection.cs
@@ -159,7 +159,7 @@ public class ShaderVariantCollection : zzio.BaseDisposable
             layouts[binding.SetIndex].Elements[binding.BindingIndex] = new(
                 binding.Name, kind, ShaderStages.Fragment | ShaderStages.Vertex);
         }
-        return layouts.Select(Factory.CreateResourceLayout).ToArray();
+        return layouts.Select(l => Factory.CreateResourceLayout(l)).ToArray();
     }
 
     private BlendStateDescription CreateBlendState(PipelineState state) => new()

--- a/zzre.core/rendering/UniformBuffer.cs
+++ b/zzre.core/rendering/UniformBuffer.cs
@@ -25,7 +25,7 @@ public class UniformBuffer<T> : BaseDisposable where T : unmanaged
         uint alignedSize = (uint)Marshal.SizeOf<T>();
         alignedSize = (alignedSize + 15) / 16 * 16;
         Buffer = factory.CreateBuffer(new BufferDescription(alignedSize, BufferUsage.UniformBuffer |
-            (dynamic ? BufferUsage.Dynamic : default)));
+            (dynamic ? BufferUsage.DynamicWrite : default)));
         Buffer.Name = $"{GetType().Name} {GetHashCode()}";
     }
 

--- a/zzre/game/systems/model/ModelRenderer.cs
+++ b/zzre/game/systems/model/ModelRenderer.cs
@@ -93,11 +93,15 @@ public partial class ModelRenderer : AEntityMultiMapSystem<CommandList, ClumpMes
         else
             clumpCounts[^1] = clumpCounts[^1].Increment();
 
+        var m = entity.TryGet<components.TexShift>().GetValueOrDefault(components.TexShift.Default).Matrix;
         instanceArena!.Add(new()
         {
             tint = materialInfo.Color,
             world = location.LocalToWorld,
-            texShift = entity.TryGet<components.TexShift>().GetValueOrDefault(components.TexShift.Default).Matrix
+            texShift = new(
+                m.M11, m.M12, 0f,
+                m.M21, m.M22, 0f,
+                m.M31, m.M32, 1f)
         });
     }
 

--- a/zzre/game/systems/sound/SoundEmitter.cs
+++ b/zzre/game/systems/sound/SoundEmitter.cs
@@ -55,7 +55,7 @@ public sealed partial class SoundEmitter : AEntitySetSystem<float>
         
         // just to be safe: also delete all sources
         using (context.EnsureIsCurrent())
-            device.AL.DeleteSources(sourcePool.ToArray());
+            device.AL.DeleteSources([.. sourcePool]);
         sourcePool.Clear();
         
         spawnEmitterSubscription?.Dispose();

--- a/zzre/materials/ModelMaterial.cs
+++ b/zzre/materials/ModelMaterial.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using Silk.NET.Maths;
 using zzio;
 using zzre.rendering;
 
@@ -28,7 +29,7 @@ public struct ModelFactors
 public struct ModelInstance
 {
     public Matrix4x4 world;
-    public Matrix3x2 texShift;
+    public Matrix3X3<float> texShift;
     public IColor tint;
 }
 
@@ -111,7 +112,7 @@ public class ModelMaterial : MlangMaterial, IStandardTransformMaterial
 public sealed class ModelInstanceBuffer : DynamicMesh
 {
     private readonly Attribute<Matrix4x4> attrWorld;
-    private readonly Attribute<Matrix3x2> attrTexShift;
+    private readonly Attribute<Matrix3X3<float>> attrTexShift;
     private readonly Attribute<IColor> attrTint;
 
     public ModelInstanceBuffer(ITagContainer diContainer,
@@ -121,7 +122,7 @@ public sealed class ModelInstanceBuffer : DynamicMesh
         : base(diContainer, dynamic, name)
     {
         attrWorld = AddAttribute<Matrix4x4>("world");
-        attrTexShift = AddAttribute<Matrix3x2>("inTexShift");
+        attrTexShift = AddAttribute<Matrix3X3<float>>("inTexShift");
         attrTint = AddAttribute<IColor>("inTint");
         Preallocate(preallocateInstances, 0);
     }

--- a/zzre/rendering/SkeletonPoseBinding.cs
+++ b/zzre/rendering/SkeletonPoseBinding.cs
@@ -25,7 +25,7 @@ public class SkeletonPoseBinding : BaseBinding
             poseBuffer?.Dispose();
             poseBuffer = Parent.Device.ResourceFactory.CreateBuffer(new BufferDescription(
                 MaxBoneCount * 4 * 4 * sizeof(float),
-                BufferUsage.StructuredBufferReadOnly | BufferUsage.Dynamic,
+                BufferUsage.StructuredBufferReadOnly | BufferUsage.DynamicWrite,
                 4 * 4 * sizeof(float)));
             poseBuffer.Name = $"{skeleton.Name} Pose {GetHashCode()}";
             poseBufferRange = new DeviceBufferRange(PoseBuffer, 0, poseBuffer.SizeInBytes);

--- a/zzre/shaders/model.mlang
+++ b/zzre/shaders/model.mlang
@@ -10,11 +10,8 @@ option HasFog;
 variants exclude if (IsSkinned && (IsInstanced || HasEnvMap || HasTexShift));
 variants exclude if (!IsInstanced && (HasTexShift || HasEnvMap || !DepthWrite || !DepthTest || Blend != IsOpaque)); // we only use opaque materials for non-instanced currently
 
-attributes
-{
-    float3 inPos;
-    byte4_norm inColor;
-}
+attributes float3 inPos;
+attributes if (!IsSkinned) byte4_norm inColor;
 attributes if (HasEnvMap) float3 inNormal;
 attributes if (!HasEnvMap) float2 inUV;
 attributes if (IsSkinned)

--- a/zzre/shaders/model.mlang
+++ b/zzre/shaders/model.mlang
@@ -21,7 +21,7 @@ attributes if (IsSkinned)
 }
 
 instances mat4 world;
-instances if (HasTexShift) mat3x2 inTexShift;
+instances if (HasTexShift) mat3 inTexShift;
 instances byte4_norm inTint;
 
 varying
@@ -127,7 +127,7 @@ vertex
     else
         uv = inUV;
     if (HasTexShift)
-        uv = inTexShift * vec3(uv, 1);
+        uv = vec3(inTexShift * vec3(uv, 1)).xy;
 	varUV = uv;
 
     if (IsSkinned)

--- a/zzre/tools/TestRaycaster.cs
+++ b/zzre/tools/TestRaycaster.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using Veldrid;
 using zzre.imgui;
 using zzre.rendering;
-using System.Linq;
 using Quaternion = System.Numerics.Quaternion;
 using zzio.vfs;
 using zzio.rwbs;
@@ -154,7 +153,7 @@ public class TestRaycaster : ListDisposable
                 : IColor.Black;
         });
 
-        device.UpdateTexture(fbArea.Framebuffer.ColorTargets.First().Target, pixels, 0, 0, 0,
+        device.UpdateTexture(fbArea.Framebuffer.ColorTargets[0].Target, pixels!, 0, 0, 0,
             fbArea.Framebuffer.Width, fbArea.Framebuffer.Height, 1,
             0, 0);
     }


### PR DESCRIPTION
Long overdue, the migration to Pizzas Veldrid fork, this should at least fix some of the validation errors regarding image transitions  and the `libdl` bug on certain linux platforms. However we should take the opportunity and check some of the other validation errors as well.
A custom fork will still be necessary as Pizza did not yet publish their fork on NuGet and we have some additional fixes we need (like UpdateBuffer_ZeroSize and portability_enumeration).

- [x] Migrate to Pizza
- [x] Fix compilation errors (mostly `BufferUsage.Dynamic` to `BufferUsage.DynamicWrite`)
- [x] Fix validation errors for vertex inputs not used <br/> At least one, the other one (related to `mat3x2`) I currently cannot explain, but because the actual usage (and more specifically the location which is marked) seem to work fine I'll ignore it for now.
- [x] Recheck validation with more pedantic rules enabled
- [x] Apply portability_enumeration fix
- [x] Retest on MacOS
- [x] Retest on Linux (also to check D32_SFloat)
- [x] Reretest on Windows to check the validation error on window close