### PR TITLE
zzre: Fix game disposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ nuget-feed
 
 # Depending on the launch directory imgui might put its ini file in the source folder
 zzre/imgui.ini
+zzre/zzre.log
 **/*.user
 **/BuildOutput.sarif
 sarif-output

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ publish
 nuget-feed
 
 # Depending on the launch directory imgui might put its ini file in the source folder
-zzre/imgui.ini
-zzre/zzre.log
+**/imgui.ini
+**/zzre.log
 **/*.user
 **/BuildOutput.sarif
 sarif-output

--- a/zzre/game/Game.cs
+++ b/zzre/game/Game.cs
@@ -39,7 +39,7 @@ public class Game : BaseDisposable, ITagContainer
 
     public Game(ITagContainer diContainer, Savegame savegame)
     {
-        tagContainer = new TagContainer().FallbackTo(diContainer);
+        tagContainer = new ExtendedTagContainer(diContainer);
         zzContainer = GetTag<IZanzarahContainer>();
         zzContainer.OnResize += HandleResize;
         logger = diContainer.GetLoggerFor<Game>();

--- a/zzre/game/UI.cs
+++ b/zzre/game/UI.cs
@@ -24,7 +24,7 @@ public class UI : BaseDisposable, ITagContainer
 
     public UI(ITagContainer diContainer)
     {
-        tagContainer = new TagContainer().FallbackTo(diContainer);
+        tagContainer = new ExtendedTagContainer(diContainer);
         zzContainer = GetTag<IZanzarahContainer>();
         zzContainer.OnResize += HandleResize;
         profiler = GetTag<Remotery>();

--- a/zzre/game/Zanzarah.cs
+++ b/zzre/game/Zanzarah.cs
@@ -37,7 +37,7 @@ public class Zanzarah : ITagContainer
 
     public Zanzarah(ITagContainer diContainer, IZanzarahContainer zanzarahContainer, Savegame? savegame = null)
     {
-        tagContainer = new TagContainer().FallbackTo(diContainer);
+        tagContainer = new ExtendedTagContainer(diContainer);
         tagContainer.AddTag(this);
         tagContainer.AddTag<IAssetLoader<Texture>>(new TextureAssetLoader(tagContainer));
         tagContainer.AddTag(zanzarahContainer);

--- a/zzre/game/systems/RecordingSequentialSystem.cs
+++ b/zzre/game/systems/RecordingSequentialSystem.cs
@@ -25,7 +25,8 @@ public class RecordingSequentialSystem<T> : ISystem<T>
 
     public void Dispose()
     {
-        foreach (var system in Systems.OfType<IDisposable>())
+        // small heurisitic with the reversing should prevent some bugs
+        foreach (var system in Systems.Reverse())
             system.Dispose();
         recorder.Dispose();
     }

--- a/zzre/game/systems/sound/SoundContext.cs
+++ b/zzre/game/systems/sound/SoundContext.cs
@@ -54,9 +54,12 @@ public sealed unsafe class SoundContext : ISystem<float>
     {
         if (context == null)
             return;
+        if (device.ALC.GetCurrentContext() == context)
+            device.ALC.MakeContextCurrent(null);
         device.ALC.DestroyContext(context);
         context = null;
         isEnabled = false;
+        device.Logger.Debug("Disposing SoundContext");
     }
 
     public void Update(float _)


### PR DESCRIPTION
As we learned, the game is not disposed at all causing many problems and many future problems. There seems to be at least two reasons for this:

- [x] Incorrect usage of `ITagContainer.FallbackTo` (not disposing the main container)
- [x] `DefaultEcs.World` does not call component removed handlers (how is this handled by `ManagedResourceSystem`?) <br/> the resource systems are disposable and are added to the TagContainer, thus (now) get disposed and take their resources with them.
- [x] OpenAL context is not destroyed as it is still current which spec disallows
- [x] SoundEmitters are not deleted as they are rare *resource components* and should be disposed manually
- [x] Is resource usage actually decreased if the game is closed?
  - As in: resource disposals are called. My debug tools currently do not show native or GPU memory usage which we should diagnose at some point.

Fixes #321 