### PR TITLE
zzre: Add waypoints section to scene editor

### DIFF
--- a/zzio/EnumerableExtensions.cs
+++ b/zzio/EnumerableExtensions.cs
@@ -112,6 +112,11 @@ public static class EnumerableExtensions
         return newOffset..(newOffset + subLength);
     }
 
+    public static Range Suffix(this Range range, int suffixLength) =>
+        range.End.IsFromEnd
+        ? range.End..(range.End.Value - suffixLength)
+        : range.End..(range.End.Value + suffixLength);
+
     public static IEnumerable<TOutput> PrefixSums<TInput, TOutput>(
         this IEnumerable<TInput> set, TOutput first, Func<TOutput, TInput, TOutput> next)
     {

--- a/zzio/primitives/IColor.cs
+++ b/zzio/primitives/IColor.cs
@@ -7,7 +7,7 @@ public struct IColor
 {
     public byte r, g, b, a;
 
-    public IColor(byte r, byte g, byte b, byte a)
+    public IColor(byte r, byte g, byte b, byte a = 255)
     {
         this.r = r;
         this.g = g;

--- a/zzio/primitives/IColor.cs
+++ b/zzio/primitives/IColor.cs
@@ -53,6 +53,7 @@ public struct IColor
     public static implicit operator FColor(IColor c) => new(c.r / 255f, c.g / 255f, c.b / 255f, c.a / 255f);
 
     public static readonly IColor White = new(0xFFFFFFFF);
+    public static readonly IColor Grey = new(0xFF808080);
     public static readonly IColor Black = new(0xFF000000);
     public static readonly IColor Clear = new(0x00000000);
     public static readonly IColor Red = new(0xFF0000FF);

--- a/zzio/scn/WaypointSystem.cs
+++ b/zzio/scn/WaypointSystem.cs
@@ -27,8 +27,7 @@ public class WaypointSystem : ISceneSection
     {
         using BinaryReader reader = new(stream);
         Version = reader.ReadUInt32();
-        uint mustBeZero = reader.ReadUInt32();
-        if (mustBeZero != 0)
+        if (reader.ReadUInt32() != 0)
             throw new InvalidDataException("Waypoint system start magic is not correct");
 
         if (Version >= 5)
@@ -65,8 +64,7 @@ public class WaypointSystem : ISceneSection
         }
         Waypoints = d;
 
-        uint mustBeFFFF = reader.ReadUInt32();
-        if (mustBeFFFF != 0xffff)
+        if (reader.ReadUInt32() != 0xffff)
             throw new InvalidDataException("Waypoint system end magic is not correct");
     }
 

--- a/zzio/scn/WaypointSystem.cs
+++ b/zzio/scn/WaypointSystem.cs
@@ -1,75 +1,69 @@
 using System;
 using System.IO;
-using System.Diagnostics;
 using System.Numerics;
+using System.Collections.Generic;
 
 // This surely needs some reverse engineering work being done...
 namespace zzio.scn;
 
 [Serializable]
-public struct WaypointInnerData
+public struct Waypoint
 {
-    public uint iiv2;
-    public uint[] data;
-}
-
-[Serializable]
-public struct WaypointData
-{
-    public uint ii1, ii1ext, iiv2;
-    public Vector3 v1;
-    public uint[] innerdata1, innerdata2;
-    public uint[]? inner3data1;
+    public uint Id, Group;
+    public Vector3 Position;
+    public uint[] WalkableIds, JumpableIds;
+    public uint[]? VisibleIds;
 }
 
 [Serializable]
 public class WaypointSystem : ISceneSection
 {
-    public uint version;
-    public byte[] data = new byte[0x18];
-    public WaypointData[] waypointData = [];
-    public WaypointInnerData[] inner2data1 = [];
+    public uint Version;
+    public byte[] Data = new byte[0x18]; // most likely just for generation? AFAIK not used in game
+    public Waypoint[] Waypoints = [];
+    public Dictionary<uint, uint[]> CompatibleGroups = [];
 
     public void Read(Stream stream)
     {
         using BinaryReader reader = new(stream);
-        version = reader.ReadUInt32();
+        Version = reader.ReadUInt32();
         uint mustBeZero = reader.ReadUInt32();
         if (mustBeZero != 0)
             throw new InvalidDataException("Waypoint system start magic is not correct");
 
-        if (version >= 5)
-            data = reader.ReadBytes(0x18);
+        if (Version >= 5)
+            Data = reader.ReadBytes(0x18);
         uint count1 = reader.ReadUInt32();
-        WaypointData[] d = new WaypointData[count1];
+        Waypoint[] d = new Waypoint[count1];
         for (uint i = 0; i < count1; i++)
         {
-            d[i].ii1 = reader.ReadUInt32();
-            if (version >= 4)
-                d[i].ii1ext = reader.ReadUInt32();
-            d[i].v1 = reader.ReadVector3();
+            d[i].Id = reader.ReadUInt32();
+            if (Version >= 4)
+                d[i].Group = reader.ReadUInt32();
+            d[i].Position = reader.ReadVector3();
 
-            d[i].innerdata1 = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
-            d[i].innerdata2 = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
+            d[i].WalkableIds = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
+            d[i].JumpableIds = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
         }
 
-        if (version >= 2)
+        if (Version >= 2)
         {
-            uint count2 = reader.ReadUInt32();
-            inner2data1 = new WaypointInnerData[count2];
-            for (uint j = 0; j < count2; j++)
+            int groupCount = reader.ReadInt32();
+            CompatibleGroups = new(groupCount);
+            for (int j = 0; j < groupCount; j++)
             {
-                inner2data1[j].iiv2 = reader.ReadUInt32();
-                inner2data1[j].data = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
+                CompatibleGroups.Add(
+                    reader.ReadUInt32(),
+                    reader.ReadStructureArray<uint>(reader.ReadInt32(), 4));
             }
         }
 
-        if (version >= 3)
+        if (Version >= 3)
         {
             for (uint j = 0; j < count1; j++)
-                d[j].inner3data1 = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
+                d[j].VisibleIds = reader.ReadStructureArray<uint>(reader.ReadInt32(), 4);
         }
-        waypointData = d;
+        Waypoints = d;
 
         uint mustBeFFFF = reader.ReadUInt32();
         if (mustBeFFFF != 0xffff)
@@ -79,46 +73,43 @@ public class WaypointSystem : ISceneSection
     public void Write(Stream stream)
     {
         using BinaryWriter writer = new(stream);
-        writer.Write(version);
+        writer.Write(Version);
         writer.Write(0);
-        if (version >= 5)
-            writer.Write(data, 0, 0x18);
-        WaypointData[] d = waypointData;
+        if (Version >= 5)
+            writer.Write(Data, 0, 0x18);
+        Waypoint[] d = Waypoints;
         writer.Write(d.Length);
         for (int i = 0; i < d.Length; i++)
         {
-            writer.Write(d[i].ii1);
-            if (version >= 4)
-                writer.Write(d[i].ii1ext);
-            writer.Write(d[i].v1);
+            writer.Write(d[i].Id);
+            if (Version >= 4)
+                writer.Write(d[i].Group);
+            writer.Write(d[i].Position);
 
-            writer.Write(d[i].innerdata1.Length);
-            for (int j = 0; j < d[i].innerdata1.Length; j++)
-                writer.Write(d[i].innerdata1[j]);
+            writer.Write(d[i].WalkableIds.Length);
+            for (int j = 0; j < d[i].WalkableIds.Length; j++)
+                writer.Write(d[i].WalkableIds[j]);
 
-            writer.Write(d[i].innerdata2.Length);
-            for (int j = 0; j < d[i].innerdata2.Length; j++)
-                writer.Write(d[i].innerdata2[j]);
+            writer.Write(d[i].JumpableIds.Length);
+            for (int j = 0; j < d[i].JumpableIds.Length; j++)
+                writer.Write(d[i].JumpableIds[j]);
         }
 
-        if (version >= 2)
+        if (Version >= 2)
         {
-            WaypointInnerData[] d2 = inner2data1;
-            writer.Write(d2.Length);
-            for (int i = 0; i < d2.Length; i++)
+            writer.Write(CompatibleGroups.Count);
+            foreach (var (groupId, wpIds) in CompatibleGroups)
             {
-                writer.Write(d2[i].iiv2);
-                writer.Write(d2[i].data.Length);
-                for (int j = 0; j < d2[i].data.Length; j++)
-                    writer.Write(d2[i].data[j]);
+                writer.Write(groupId);
+                writer.WriteStructureArray(wpIds, 4);
             }
         }
 
-        if (version >= 3)
+        if (Version >= 3)
         {
             for (int i = 0; i < d.Length; i++)
             {
-                var links = d[i].inner3data1 ?? [];
+                var links = d[i].VisibleIds ?? [];
                 writer.Write(links.Length);
                 writer.WriteStructureArray(links, 4);
             }

--- a/zzio/utils/BinaryIOExtension.cs
+++ b/zzio/utils/BinaryIOExtension.cs
@@ -54,6 +54,7 @@ public static class BinaryIOExtension
 
     public static T[] ReadStructureArray<T>(this BinaryReader reader, int count, int expectedSizeOfElement) where T : unmanaged
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         var array = new T[count];
         reader.ReadStructureArray(array, expectedSizeOfElement);
         return array;

--- a/zzre.core/imgui/MenuBar.cs
+++ b/zzre.core/imgui/MenuBar.cs
@@ -80,6 +80,24 @@ public class MenuBar
         EndMenu();
     });
 
+    public void AddRadio<TEnum>(string path, GetRefValueFunc<TEnum> getValue, Action? onChanged = null)
+        where TEnum : struct, Enum => AddItem(path, name =>
+    {
+        if (!BeginMenu(name))
+            return;
+        ref var curValue = ref getValue();
+        var values = Enum.GetValues<TEnum>();
+        foreach (var value in values)
+        {
+            if (MenuItem(value.ToString(), "", curValue.GetHashCode() == value.GetHashCode()))
+            {
+                curValue = value;
+                onChanged?.Invoke();
+            }
+        }
+        EndMenu();
+    });
+
     public void AddSlider(string path, float minVal, float maxVal, GetRefValueFunc<float> getValue, Action? onChanged = null) => AddItem(path, name =>
     {
         if (SliderFloat(name, ref getValue(), minVal, maxVal))

--- a/zzre.core/math/Frustum.cs
+++ b/zzre.core/math/Frustum.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace zzre;

--- a/zzre.core/math/MathEx.cs
+++ b/zzre.core/math/MathEx.cs
@@ -148,7 +148,7 @@ public static class MathEx
     public static IEnumerable<FColor> GoldenRatioColors(
         float hueStart = 0f,
         float saturation = 1f,
-        float luminosity = 1f,
+        float luminosity = 0.5f,
         float alpha = 1f) =>
         GoldenRatioSequence(hueStart)
         .Select(hue => new FColor(hue, saturation, luminosity, alpha).HSLToRGB());

--- a/zzre.core/math/MathEx.cs
+++ b/zzre.core/math/MathEx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using zzio;
 
 namespace zzre;
 
@@ -131,4 +132,24 @@ public static class MathEx
             from.Y,
             MathF.Cos(newAngle));
     }
+
+    public const float GoldenRatioFract = 0.61803398875f;
+    public const float GoldenRatio = 1.61803398875f;
+
+    public static IEnumerable<float> GoldenRatioSequence(float acc = 0f)
+    {
+        while (true)
+        {
+            yield return acc;
+            acc = (acc + GoldenRatioFract) % 1f;
+        }
+    }
+
+    public static IEnumerable<FColor> GoldenRatioColors(
+        float hueStart = 0f,
+        float saturation = 1f,
+        float luminosity = 1f,
+        float alpha = 1f) =>
+        GoldenRatioSequence(hueStart)
+        .Select(hue => new FColor(hue, saturation, luminosity, alpha).HSLToRGB());
 }

--- a/zzre/materials/DebugMaterial.cs
+++ b/zzre/materials/DebugMaterial.cs
@@ -44,6 +44,7 @@ public class DebugMaterial : MlangMaterial, IStandardTransformMaterial
     public ColorMode Color { set => SetOption(nameof(ColorMode), (uint)value); }
     public TopologyMode Topology { set => SetOption(nameof(Topology), (uint)value); }
     public bool BothSided { set => SetOption(nameof(BothSided), value); }
+    public bool DepthTest { set => SetOption(nameof(DepthTest), value); }
 
     public UniformBinding<Matrix4x4> Projection { get; }
     public UniformBinding<Matrix4x4> View { get; }

--- a/zzre/shaders/debug.mlang
+++ b/zzre/shaders/debug.mlang
@@ -2,6 +2,7 @@ option IsSkinned;
 option ColorMode = VertexColor, SkinWeights, SingleBoneWeight;
 option Topology = Triangles, Lines;
 option BothSided;
+option DepthTest;
 
 variants exclude if (ColorMode != VertexColor && IsSkinned);
 variants exclude if (Topology == Lines && BothSided);
@@ -41,6 +42,12 @@ pipeline if (Topology == Lines)
 pipeline if (BothSided)
 {
 	cull none;
+}
+
+pipeline if (DepthTest)
+{
+	DepthTest On;
+	DepthWrite On;
 }
 
 vec4 GetDebugColorOf(uint index)

--- a/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
+++ b/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
@@ -2,12 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using DefaultEcs.System;
-using Silk.NET.Core.Native;
 using Veldrid;
 using zzio;
 using zzio.scn;
-using zzre.debug;
 using zzre.imgui;
 using zzre.materials;
 using zzre.rendering;
@@ -39,15 +36,15 @@ public partial class SceneEditor
 
         private readonly DebugLineRenderer lineRenderer;
         private readonly SceneEditor editor;
-        private readonly Dictionary<(int, int), bool> walkableLinks = new(), jumpableLinks = new();
-        private readonly Dictionary<uint, int> idToIndex = new();
-        private readonly Dictionary<uint, (IColor full, IColor half)> groupColors = new();
+        private readonly Dictionary<(int, int), bool> walkableLinks = [], jumpableLinks = [];
+        private readonly Dictionary<uint, int> idToIndex = [];
+        private readonly Dictionary<uint, (IColor full, IColor half)> groupColors = [];
 
         private Range rangePoints, rangeTraversableEdges;
         private bool
             showPoints = true,
             showTraversableEdges = true,
-            colorGroups = false,
+            colorGroups,
             hasPrecomputedVisibility;
         private EdgeVisibility edgeVisibility = EdgeVisibility.Traversable; // for selected waypoints
         private Selection selection = Selection.None;
@@ -226,7 +223,7 @@ public partial class SceneEditor
                 : edgeVisibility is EdgeVisibility.Traversable ? waypoint.Value.WalkableIds.Concat(waypoint.Value.JumpableIds)
                 : edgeVisibility is EdgeVisibility.Visibility ? waypoint.Value.VisibleIds
                 : null)
-                ?? Enumerable.Empty<uint>();
+                ?? [];
             for (int i = 0; i < wpSystem.Waypoints.Length; i++)
             {
                 if (i == selectedWaypoint)

--- a/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
+++ b/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Veldrid;
+using zzio;
+using zzio.scn;
+using zzre.debug;
+using zzre.imgui;
+using zzre.materials;
+using zzre.rendering;
+using static ImGuiNET.ImGui;
+using static zzre.imgui.ImGuiEx;
+using Quaternion = System.Numerics.Quaternion;
+
+namespace zzre.tools;
+
+public partial class SceneEditor
+{
+    private sealed class WaypointComponent : BaseDisposable
+    {
+        private enum EdgeVisibility
+        {
+            None,
+            Traversable,
+            Visibility
+        }
+
+        private readonly DebugLineRenderer lineRenderer;
+        private readonly SceneEditor editor;
+
+        private Range rangePoints, rangeTraversableEdges, rangeVisibleEdges;
+        private bool showPoints = true;
+        private EdgeVisibility edgeVisibility = EdgeVisibility.Traversable;
+
+        public WaypointComponent(ITagContainer diContainer)
+        {
+            diContainer.AddTag(this);
+            editor = diContainer.GetTag<SceneEditor>();
+            editor.fbArea.OnRender += HandleRender;
+            editor.OnLoadScene += HandleLoadScene;
+            editor.editor.AddInfoSection("Waypoints", HandleInfoSection, false);
+
+            var menuBar = diContainer.GetTag<MenuBarWindowTag>();
+            menuBar.AddCheckbox("View/Waypoints/Points", () => ref showPoints, () => editor.fbArea.IsDirty = true);
+            menuBar.AddRadio("View/Waypoints/Edges", () => ref edgeVisibility, () => editor.fbArea.IsDirty = true);
+
+            lineRenderer = new(diContainer);
+            lineRenderer.Material.LinkTransformsTo(diContainer.GetTag<Camera>());
+            lineRenderer.Material.World.Ref = Matrix4x4.Identity;
+            lineRenderer.Material.DepthTest = true;
+        }
+
+        protected override void DisposeManaged()
+        {
+            base.DisposeManaged();
+            lineRenderer.Dispose();
+        }
+
+        private void HandleLoadScene()
+        {
+            lineRenderer.Clear();
+            showPoints = true;
+            edgeVisibility = EdgeVisibility.Traversable;
+            if (editor.scene == null)
+                return;
+
+            var wpSystem = editor.scene.waypointSystem;
+            rangePoints = 0..(wpSystem.waypointData.Length * 3);
+            lineRenderer.Reserve(wpSystem.waypointData.Length * 3);
+            foreach (var wp in wpSystem.waypointData)
+                lineRenderer.AddCross(IColor.White, wp.v1, 0.1f);
+        }
+        
+        private void HandleRender(CommandList cl)
+        {
+            if (lineRenderer.Count == 0)
+                return;
+
+            if (showPoints)
+                lineRenderer.Render(cl, rangePoints);
+            switch (edgeVisibility)
+            {
+                case EdgeVisibility.None: break;
+                case EdgeVisibility.Traversable: lineRenderer.Render(cl, rangeTraversableEdges); break;
+                case EdgeVisibility.Visibility: lineRenderer.Render(cl, rangeVisibleEdges); break;
+                default: throw new NotImplementedException($"Unimplemented edge visibility mode: {edgeVisibility}");
+            }
+        }
+
+        private void HandleInfoSection()
+        {
+            var wpSystem = editor.scene?.waypointSystem;
+            LabelText("Waypoints", wpSystem?.waypointData?.Length.ToString() ?? "");
+        }
+    }
+}

--- a/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
+++ b/zzre/tools/sceneeditor/SceneEditor.Waypoints.cs
@@ -68,18 +68,18 @@ public partial class SceneEditor
                 return;
 
             var wpSystem = editor.scene.waypointSystem;
-            var idToIndex = wpSystem.waypointData.Indexed().ToDictionary(t => t.Value.ii1, t => t.Index);
-            var walkableLinks = LinkSet(wpSystem.waypointData.Select(wp => wp.innerdata1));
-            var jumpableLinks = LinkSet(wpSystem.waypointData.Select(wp => wp.innerdata2));
-            hasPrecomputedVisibility = wpSystem.waypointData.Any(wp => wp.inner3data1?.Length > 0);
+            var idToIndex = wpSystem.Waypoints.Indexed().ToDictionary(t => t.Value.Id, t => t.Index);
+            var walkableLinks = LinkSet(wpSystem.Waypoints.Select(wp => wp.WalkableIds));
+            var jumpableLinks = LinkSet(wpSystem.Waypoints.Select(wp => wp.JumpableIds));
+            hasPrecomputedVisibility = wpSystem.Waypoints.Any(wp => wp.VisibleIds?.Length > 0);
 
-            rangePoints = 0..(wpSystem.waypointData.Length * 3);
+            rangePoints = 0..(wpSystem.Waypoints.Length * 3);
             rangeTraversableEdges = rangePoints.Suffix(walkableLinks.Count + jumpableLinks.Count);
             lineRenderer.Reserve(
-                wpSystem.waypointData.Length * 3 +
+                wpSystem.Waypoints.Length * 3 +
                 walkableLinks.Count + jumpableLinks.Count);
-            foreach (var wp in wpSystem.waypointData)
-                lineRenderer.AddCross(IColor.White, wp.v1, 0.1f);
+            foreach (var wp in wpSystem.Waypoints)
+                lineRenderer.AddCross(IColor.White, wp.Position, 0.1f);
             AddLinkSet(walkableLinks, new(0, 0, 230), new(0, 0, 130));
             AddLinkSet(jumpableLinks, new(230, 0, 0), new(130, 0, 0));
 
@@ -88,8 +88,8 @@ public partial class SceneEditor
                 foreach (var ((linkFrom, linkTo), isFull) in linkSet)
                     lineRenderer.Add(
                         isFull ? fullColor : halfColor,
-                        wpSystem.waypointData[linkFrom].v1,
-                        wpSystem.waypointData[linkTo].v1);
+                        wpSystem.Waypoints[linkFrom].Position,
+                        wpSystem.Waypoints[linkTo].Position);
             }
 
             Dictionary<(int, int), bool> LinkSet(IEnumerable<IEnumerable<uint>?> halfLinks)
@@ -127,8 +127,8 @@ public partial class SceneEditor
         private void HandleInfoSection()
         {
             var wpSystem = editor.scene?.waypointSystem;
-            LabelText("Version", wpSystem?.version.ToString() ?? "n/a");
-            LabelText("Waypoints", wpSystem?.waypointData?.Length.ToString() ?? "");
+            LabelText("Version", wpSystem?.Version.ToString() ?? "n/a");
+            LabelText("Waypoints", wpSystem?.Waypoints?.Length.ToString() ?? "");
             LabelText("Precomp. visibility", hasPrecomputedVisibility.ToString());
         }
     }

--- a/zzre/tools/sceneeditor/SceneEditor.cs
+++ b/zzre/tools/sceneeditor/SceneEditor.cs
@@ -86,6 +86,7 @@ public partial class SceneEditor : ListDisposable, IDocumentEditor
         new LightComponent(localDiContainer);
         new EffectComponent(localDiContainer);
         new Sample3DComponent(localDiContainer);
+        new WaypointComponent(localDiContainer);
         new SelectionComponent(localDiContainer);
         diContainer.GetTag<OpenDocumentSet>().AddEditor(this);
     }


### PR DESCRIPTION
In preparation of enemy fairy movement I added a visualization of the waypoints in duel scenes to the scene editor with various features to select single waypoints or waypoint groups.

![image](https://github.com/user-attachments/assets/1817cf16-a40b-4c0f-88b1-612dbe607b7c)
