### PR TITLE
CI: Lock linux runner to ubuntu-22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22, windows-latest, macos-13, macos-14]
+        os: [ubuntu-22.04, windows-latest, macos-13, macos-14]
     uses: ./.github/workflows/build.yml
     with:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-22, windows-latest, macos-13, macos-14]
     uses: ./.github/workflows/build.yml
     with:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22]
+        os: [ubuntu-22.04]
     uses: ./.github/workflows/build.yml
     with:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22]
     uses: ./.github/workflows/build.yml
     with:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
There is some library incompatibility in ubuntu-24 that we should look at in more detail. In the meantime GitHub will support ubuntu-22 for a while longer, so we just use that.