### PR TITLE
zzre: Add world components to ECSExplorer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="GitInfo" Version="3.3.5" /> <!-- Later versions changed license -->
     
     <!-- zzre.core -->
-    <PackageVersion Include="DefaultEcs" Version="1.0.0-6c35427" /> <!-- Forked for fixes and safe-mode -->
-    <PackageVersion Include="DefaultEcs.Safe" Version="1.0.0-safe-6c35427" />
+    <PackageVersion Include="DefaultEcs" Version="1.0.0-20e53ce" /> <!-- Forked for fixes and safe-mode -->
+    <PackageVersion Include="DefaultEcs.Safe" Version="1.0.0-safe-20e53ce" />
     <PackageVersion Include="DefaultEcs.Analyzer" Version="0.17.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,8 @@
     <PackageVersion Include="GitInfo" Version="3.3.5" /> <!-- Later versions changed license -->
     
     <!-- zzre.core -->
-    <PackageVersion Include="DefaultEcs" Version="1.0.0-safe-0e92bb5" /> <!-- Forked for fixes and safe-mode -->
+    <PackageVersion Include="DefaultEcs" Version="1.0.0-6c35427" /> <!-- Forked for fixes and safe-mode -->
+    <PackageVersion Include="DefaultEcs.Safe" Version="1.0.0-safe-6c35427" />
     <PackageVersion Include="DefaultEcs.Analyzer" Version="0.17.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="GitInfo" Version="3.3.5" /> <!-- Later versions changed license -->
     
     <!-- zzre.core -->
-    <PackageVersion Include="DefaultEcs" Version="1.0.0-20e53ce" /> <!-- Forked for fixes and safe-mode -->
-    <PackageVersion Include="DefaultEcs.Safe" Version="1.0.0-safe-20e53ce" />
+    <PackageVersion Include="DefaultEcs" Version="1.0.0-e5ec72b" /> <!-- Forked for fixes and safe-mode -->
+    <PackageVersion Include="DefaultEcs.Safe" Version="1.0.0-safe-e5ec72b" />
     <PackageVersion Include="DefaultEcs.Analyzer" Version="0.17.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -15,6 +15,7 @@
       <package pattern="Veldrid"/>
       <package pattern="Veldrid*"/>
       <package pattern="DefaultEcs"/>
+      <package pattern="DefaultEcs.Safe"/>
       <package pattern="ImGui.NET"/>
       <package pattern="ImGuizmo.NET"/>
       <package pattern="Mlang"/>

--- a/zzio.slnx
+++ b/zzio.slnx
@@ -10,6 +10,7 @@
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
     <File Path="NoCodeQuality.props" />
+    <File Path="nuget.config" />
   </Folder>
   <Folder Name="/cli/">
     <Project Path="zzio_cli/zzio_cli.csproj" />

--- a/zzre.core/zzre.core.csproj
+++ b/zzre.core/zzre.core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Mlang" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="DefaultEcs" />
+    <PackageReference Include="DefaultEcs.Safe" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'!='Debug'">
     <PackageReference Include="DefaultEcs" />

--- a/zzre/tools/ECSExplorer/ECSExplorer.cs
+++ b/zzre/tools/ECSExplorer/ECSExplorer.cs
@@ -1,13 +1,12 @@
 ﻿namespace zzre.tools;
+using IconFonts;
+using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using IconFonts;
-using ImGuiNET;
 using zzre.game.components;
 using zzre.imgui;
-
 using static ImGuiNET.ImGui;
 
 internal interface IECSWindow
@@ -56,6 +55,8 @@ internal sealed partial class ECSExplorer
     private static void HandleContentFor(DefaultEcs.World world)
     {
         var entityContentRenderer = new EntityContentRenderer();
+
+        HandleWorldComponentsFor(world);
 
         var children = world.ToLookup(e => e.TryGet<Parent>().GetValueOrDefault().Entity);
 
@@ -117,6 +118,37 @@ internal sealed partial class ECSExplorer
             }
             PopID();
             SameLine();
+        }
+    }
+
+    private static void HandleWorldComponentsFor(DefaultEcs.World world)
+    {
+        var hasAny = new CountComponentReader();
+        world.ReadAllWorldComponents(hasAny);
+        if (hasAny.ComponentCount == 0)
+            return;
+
+        var entityContentRenderer = new EntityContentRenderer();
+        if (!TreeNodeEx("World", ImGuiTreeNodeFlags.Framed | ImGuiTreeNodeFlags.OpenOnDoubleClick | ImGuiTreeNodeFlags.OpenOnArrow))
+            return;
+        if (!BeginTable("components", 2, ImGuiTableFlags.BordersOuter | ImGuiTableFlags.RowBg))
+        {
+            TreePop();
+            return;
+        }
+        TableSetupColumn("Name");
+        TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
+        world.ReadAllWorldComponents(entityContentRenderer);
+        EndTable();
+        TreePop();
+    }
+
+    private sealed class CountComponentReader : DefaultEcs.Serialization.IComponentReader
+    {
+        public int ComponentCount { get; private set; }
+        public void OnRead<T>(in T component, in DefaultEcs.Entity componentOwner)
+        {
+            ComponentCount++;
         }
     }
 


### PR DESCRIPTION
I also added removing unused keys from `EntityMultiMap` when calling `TrimExcess`, so #333 should be solvable now.

Fixes #440 