### PR TITLE
fix: make Savegame.Write output readable again

### DIFF
--- a/zzio.tests/zzio/TestSavegame.cs
+++ b/zzio.tests/zzio/TestSavegame.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace zzio.tests;
+
+[TestFixture]
+public class TestSavegame
+{
+    /// <summary>Write -> Read must reproduce the savegame, especially the
+    /// game state mods whose type prefix Write historically dropped</summary>
+    [Test]
+    public void RoundtripWithGameStateMods()
+    {
+        var savegame = new Savegame
+        {
+            sceneId = 2801,
+            entryId = 3,
+            name = "roundtrip",
+            secondsPlayed = 123,
+            progress = 4,
+            pixiesHolding = 2,
+            pixiesCatched = 1,
+            switchGameMinMoves = 7
+        };
+        savegame.gameState["sc_2801"] =
+        [
+            new GSModRemoveItem(11),
+            new GSModRemoveModel(22),
+            new GSModSetTrigger(33, 44, 45, 46, 47),
+            new GSModChangeNPCState(55, new UID(0xCAFE)),
+            new GSModDisableAttackTrigger(66),
+            new GSModDisableTrigger(77),
+            new GSModSetNPCModifier(88, -1),
+        ];
+        var item = new InventoryItem
+        {
+            cardId = new CardId(CardType.Item, 21),
+            atIndex = 0,
+            dbUID = new UID(0xBEEF),
+            amount = 1,
+            isInUse = false
+        };
+        savegame.inventory.Add(item);
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+            savegame.Write(writer);
+        stream.Position = 0;
+
+        Savegame result;
+        using (var reader = new BinaryReader(stream))
+            result = Savegame.ReadNew(reader);
+
+        Assert.That(result.sceneId, Is.EqualTo(2801));
+        Assert.That(result.entryId, Is.EqualTo(3));
+        Assert.That(result.secondsPlayed, Is.EqualTo(123));
+        Assert.That(result.progress, Is.EqualTo(4));
+        Assert.That(result.gameState, Contains.Key("sc_2801"));
+        var mods = result.gameState["sc_2801"];
+        Assert.That(mods, Has.Count.EqualTo(7));
+        Assert.That(mods[0], Is.EqualTo(new GSModRemoveItem(11)));
+        Assert.That(mods[1], Is.EqualTo(new GSModRemoveModel(22)));
+        Assert.That(mods[2], Is.EqualTo(new GSModSetTrigger(33, 44, 45, 46, 47)));
+        Assert.That(mods[3], Is.EqualTo(new GSModChangeNPCState(55, new UID(0xCAFE))));
+        Assert.That(mods[4], Is.EqualTo(new GSModDisableAttackTrigger(66)));
+        Assert.That(mods[5], Is.EqualTo(new GSModDisableTrigger(77)));
+        Assert.That(mods[6], Is.EqualTo(new GSModSetNPCModifier(88, -1)));
+        Assert.That(result.inventory, Has.Count.EqualTo(1));
+        Assert.That(result.inventory[0].cardId, Is.EqualTo(item.cardId));
+        Assert.That(result.inventory[0].amount, Is.EqualTo(1u));
+        Assert.That(result.pixiesHolding, Is.EqualTo(2u));
+        Assert.That(result.pixiesCatched, Is.EqualTo(1u));
+        Assert.That(result.switchGameMinMoves, Is.EqualTo(7u));
+    }
+}

--- a/zzio/Savegame.cs
+++ b/zzio/Savegame.cs
@@ -95,6 +95,12 @@ public class Savegame
     {
         version.Write(w);
         w.WriteZString(name);
+        // ReadNew liest diese beiden Felder vor dem Location-Block — ohne sie
+        // ist jedes selbst geschriebene Savegame unlesbar (der Leser nimmt
+        // LocationBlockSize als secondsPlayed und scheitert zwei Felder spaeter
+        // am Groessen-Check).
+        w.Write(secondsPlayed);
+        w.Write(progress);
         w.Write(LocationBlockSize);
         w.Write(sceneId);
         w.Write(entryId);

--- a/zzio/Savegame.cs
+++ b/zzio/Savegame.cs
@@ -111,7 +111,14 @@ public class Savegame
             w.WriteZString(sceneName);
             w.Write(mods.Count);
             foreach (var mod in mods)
+            {
+                // ReadNew reads the type before the payload, but the mods'
+                // Write methods only write their payload — without this
+                // prefix any savegame containing game state mods (a first
+                // picked-up item, an opened chest, ...) is unreadable.
+                w.Write((int)mod.Type);
                 mod.Write(w);
+            }
         }
 
         w.Write(inventory.Count);


### PR DESCRIPTION
Two write/read asymmetries made every savegame written by zzio unreadable by zzio itself:

1. `ReadNew` reads `secondsPlayed` and `progress` right after the name, but `Write` never wrote them — the reader takes `LocationBlockSize` for `secondsPlayed` and fails the size check two fields later.
2. `IGameStateMod.ReadNew` reads the mod type (Int32) before the payload, but the mods' `Write` methods only serialize their payload and `Savegame.Write` never wrote the prefix. Any savegame containing game state mods (a first picked-up item, an opened chest, ...) fails in `intToEnum` since `GameStateModType` has no `Unknown` value.

Both went unnoticed so far because nothing in zzre saves yet; found while adding autosave to an iOS port (the second one the hard way, after the first collected item silently broke the save).

Adds a roundtrip test covering all seven mod types plus an inventory card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)