### PR TITLE
fix: compute skeleton pose on CPU before mapping the pose buffer

### DIFF
--- a/zzre/rendering/SkeletonPoseBinding.cs
+++ b/zzre/rendering/SkeletonPoseBinding.cs
@@ -12,6 +12,7 @@ public class SkeletonPoseBinding : BaseBinding
     private bool isContentDirty = true;
     private DeviceBuffer? poseBuffer;
     private DeviceBufferRange poseBufferRange;
+    private Matrix4x4[] poseMatrices = [];
 
     public Skeleton? Skeleton
     {
@@ -28,6 +29,8 @@ public class SkeletonPoseBinding : BaseBinding
                 4 * 4 * sizeof(float)));
             poseBuffer.Name = $"{field.Name} Pose {GetHashCode()}";
             poseBufferRange = new DeviceBufferRange(PoseBuffer, 0, poseBuffer.SizeInBytes);
+            if (poseMatrices.Length < field.Bones.Count)
+                poseMatrices = new Matrix4x4[field.Bones.Count];
             isContentDirty = true;
             isBindingDirty = true;
         }
@@ -52,18 +55,29 @@ public class SkeletonPoseBinding : BaseBinding
             return;
         isContentDirty = false;
 
-        var map = Parent.Device.Map<Matrix4x4>(poseBuffer, MapMode.Write);
+        // Erst vollstaendig auf der CPU rechnen, dann am Stueck in den gemappten
+        // Puffer schreiben. Vorher wurde die Hierarchie direkt im gemappten
+        // GPU-Speicher aufgeloest (map[i] = ... * map[parentI]) — ein Rueckwaerts-
+        // lesen aus Write-gemapptem Speicher. Auf Desktop-GPUs (gecachter Unified
+        // Memory) geht das zufaellig gut; auf write-combined Upload-Speicher wie
+        // dem des Apple A12 liefert es zeitweise veraltete Werte, und Kind-Bones
+        // (Arme, Haende) erben dann kaputte Eltern-Matrizen — sichtbar als vom
+        // Koerper geloeste, in der Luft fliegende Gliedmassen.
         for (int i = 0; i < Skeleton.Bones.Count; i++)
         {
             var parentI = Skeleton.Parents[i];
             Debug.Assert(parentI < i);
             Debug.Assert(parentI < 0 || Skeleton.Bones[parentI] == Skeleton.Bones[i].Parent);
-            map[i] = parentI < 0
+            poseMatrices[i] = parentI < 0
                 ? Skeleton.Bones[i].ParentToLocal
-                : Skeleton.Bones[i].ParentToLocal * map[parentI];
+                : Skeleton.Bones[i].ParentToLocal * poseMatrices[parentI];
         }
         for (int i = 0; i < Skeleton.Bones.Count; i++)
-            map[i] = Skeleton.BindingObjectToBone[i] * map[i];
+            poseMatrices[i] = Skeleton.BindingObjectToBone[i] * poseMatrices[i];
+
+        var map = Parent.Device.Map<Matrix4x4>(poseBuffer, MapMode.Write);
+        for (int i = 0; i < Skeleton.Bones.Count; i++)
+            map[i] = poseMatrices[i];
         Parent.Device.Unmap(poseBuffer);
     }
 }


### PR DESCRIPTION
`SkeletonPoseBinding` resolved the bone hierarchy directly inside the write-mapped buffer (`map[i] = ... * map[parentI]`), reading back previously written entries. On cached unified memory (desktop) this happens to work; on write-combined upload memory (Apple A12/iPad via MoltenVK) the read-back intermittently returns stale data — limbs detach from the body and float mid-air.

Compute the pose in a CPU array first, then copy once into the mapped buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)