### PR TITLE
fix: clamp XP level-ups at the internal level cap 59

### DIFF
--- a/zzre/game/Inventory.GameLogic.cs
+++ b/zzre/game/Inventory.GameLogic.cs
@@ -115,7 +115,11 @@ public partial class Inventory
         {
             // TODO: Refactor original XP increase method
             fairy.xp = Math.Min(MaxXP, fairy.xp + 1);
-            var newLevel = GetLevelByXP(fairy);
+            // clamp at the internal level cap 59 (= displayed 60): the raw
+            // curve yields 60 at the XP cap 15000 for 9 of the 12 levelup
+            // values in the fairy database, but the original engine has no
+            // level-up threshold beyond 59 (also see GetLevelupXP below)
+            var newLevel = Math.Min(GetLevelByXP(fairy), (uint)(MaxLevel - 1));
             if (newLevel <= fairy.level)
                 continue;
             // TODO: Handle fairy attribute change upon level change


### PR DESCRIPTION
The level curve `(uint)(pow(xp, f) * 60 / pow(15000, f))` evaluates to 60 at the XP cap of 15000 for 9 of the 12 `levelup` values found in the fairy database (320, 330, 348, 350, 360, 370, 400, 410, 700 — only 300/390/450 stay at 59 due to rounding). `AddXP` would then assign `fairy.level = 60`, which the original engine never reaches: its level-up table has no threshold beyond the internal level 59 (displayed as 60), consistent with `GetLevelupXP` returning null from level 59 on. The overshoot is savegame-persistent via `InventoryFairy.level`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)